### PR TITLE
Support JPY currency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ An [unreleased] version is not available on `master` branch and is subject to ch
 
 [unreleased]
 ------------
+- *`Added`* Support `JPY` currency
+- *`Improved`* Code Refactoring
 - *`Updated`* Updated README.md file
 - *`Updated`* Changed compatible version number from `1.5.x` to `2.0.x`
 - *`Updated`* Updated Opencart2.0 interface images

--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -1,217 +1,43 @@
 <?php
 class ControllerPaymentOmise extends Controller {
     /**
-     * $error
+     * @var array
      */
     private $error = array();
 
     /**
-     * This method will fire when user click `install` button from `extension/payment` page
-     * It will call `model/payment/omise.php` file and run `install` method for installl something
-     * that necessary to use in Omise Payment Gateway module
-     * @return void
+     * @return string
      */
-    public function install() {
-        $this->load->model('payment/omise');
-
-        try {
-            // Install the extension
-            if (!$this->model_payment_omise->install())
-                throw new Exception('', 1);
-        } catch (Exception $e) {
-            // Uninstall
-            $this->load->controller('extension/payment/uninstall');
-        }
-    }
-
-    /**
-     * This method will fire when user click `Uninstall` button from `extension/payment` page
-     * Uninstall anything about Omise Payment Gateway module that installed.
-     * @return void
-     */
-    public function uninstall() {
-        //
-    }
-
-    public function index() {
-        $this->load->model('payment/omise');
-        $this->load->model('setting/setting');
-        $this->load->model('localisation/currency');
-        $this->load->language('payment/omise');
-        $this->document->setTitle($this->language->get('heading_title'));
-        
-        $data = array();
-
-        /**
-         * POST Request handle.
-         *
-         */
-        if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
-            $update = $this->request->post;
-            $update['omise_3ds'] = isset($update['omise_3ds']) ? $update['omise_3ds'] : 0;
-
-            // Update
-            $this->model_setting_setting->editSetting('omise', $update);
-
-            $this->session->data['success'] = $this->language->get('text_session_save');
-            $this->response->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
-        }
-
-        // Setup error warning message
-        if (isset($this->error['warning'])) {
-            $data['error_warning'] = $this->error['warning'];
-        } else {
-            $data['error_warning'] = '';
-        }
-
-        // Setup success message
+    private function flashSuccessMessages() {
         if (isset($this->session->data['success'])) {
-            $data['success'] = $this->session->data['success'];
-
+            $msg = $this->session->data['success'];
             unset($this->session->data['success']);
-        } else {
-            $data['success'] = '';
+
+            return $msg;
         }
 
-        // Page data. Setting tab
-        $data = array_merge($data, array(
-            'omise_status'        => $this->config->get('omise_status'),
-            'omise_test_mode'     => $this->config->get('omise_test_mode'),
-            'omise_3ds'           => $this->config->get('omise_3ds'),
-            'omise_pkey_test'     => $this->config->get('omise_pkey_test'),
-            'omise_skey_test'     => $this->config->get('omise_skey_test'),
-            'omise_pkey'          => $this->config->get('omise_pkey'),
-            'omise_skey'          => $this->config->get('omise_skey'),
-            'omise_payment_title' => $this->config->get('omise_payment_title')
-        ));
-
-        // Page data. Dashboard tab
-        $data = array_merge($data, array(
-            'omise_dashboard' => array(
-                'error_danger'  => '',
-                'error_warning' => '',
-                'enabled'       => $this->config->get('omise_status')
-            )
-        ));
-
-        if (!$data['omise_dashboard']['enabled']) {
-            $data['omise_dashboard']['error_danger'][] = $this->language->get('error_extension_disabled');
-        } else {
-            try {
-                // Retrieve Omise Account.
-                $omise_account = $this->model_payment_omise->getOmiseAccount();
-                if (isset($omise_account['error']))
-                    throw new Exception('Omise Account:: '.$omise_account['error'], 1); 
-
-                $data['omise_dashboard']['account']['email']     = $omise_account['email'];
-                $data['omise_dashboard']['account']['created']   = $omise_account['created'];
-
-                // Retrieve Omise Balance.
-                $omise_balance = $this->model_payment_omise->getOmiseBalance();
-                if (isset($omise_balance['error']))
-                    throw new Exception('Omise Balance:: '.$omise_balance['error'], 1);
-
-                $data['omise_dashboard']['balance']['livemode']  = $omise_balance['livemode'];
-                $data['omise_dashboard']['balance']['available'] = $omise_balance['available'];
-                $data['omise_dashboard']['balance']['total']     = $omise_balance['total'];
-                $data['omise_dashboard']['balance']['currency']  = $omise_balance['currency'];
-
-                // Retrieve Omise Charge List.
-                $omise_charge = $this->model_payment_omise->getOmiseChargeList();
-                if (isset($omise_charge['error']))
-                    throw new Exception('Omise Charge:: '.$omise_charge['error'], 1);
-
-                $data['omise_dashboard']['charge']['data']       = $omise_charge['data'];
-                $data['omise_dashboard']['charge']['total']      = $omise_charge['total'];
-
-                // Retrieve Omise Transfer List.
-                $omise_transfer = $this->model_payment_omise->getOmiseTransferList();
-                if (isset($omise_transfer['error']))
-                    throw new Exception('Omise Transfer:: '.$omise_transfer['error'], 1);
-
-                $data['omise_dashboard']['transfer']['data']     = $omise_transfer['data'];
-                $data['omise_dashboard']['transfer']['total']    = $omise_transfer['total'];
-            } catch (Exception $e) {
-                $data['omise_dashboard']['error_danger'][] = $e->getMessage();
-            }
-        }
-
-        // Check currency supported
-        if (empty($this->model_localisation_currency->getCurrencyByCode('THB'))) {
-            $data['omise_dashboard']['error_warning'][] = $this->language->get('error_currency_thb_not_found').' <a href="'.$this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL').'">setup</a> or <a href="http://docs.opencart.com/system/localisation/currency">learn more</a>';
-        }
-
-        if (strtolower($this->config->get('config_currency')) !== 'thb') {
-            $data['omise_dashboard']['error_warning'][] = $this->language->get('error_currency_no_support').' Your default currency is <strong>'.$this->config->get('config_currency').'</strong>.'.' <a href="'.$this->url->link('setting/store', 'token=' . $this->session->data['token'], 'SSL').'">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
-        }
-
-        // Page labels
-        $data = array_merge($data, array(
-            'heading_title'             => $this->language->get('heading_title'),
-            'button_save'               => $this->language->get('button_save'),
-            'action'                    => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),
-            'button_cancel'             => $this->language->get('button_cancel'),
-            'cancel'                    => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
-            'text_form'                 => $this->language->get('text_form'),
-            'entry_status'              => $this->language->get('entry_status'),
-            'text_enabled'              => $this->language->get('text_enabled'),
-            'text_disabled'             => $this->language->get('text_disabled'),
-            'label_omise_pkey_test'     => $this->language->get('label_omise_pkey_test'),
-            'label_omise_skey_test'     => $this->language->get('label_omise_skey_test'),
-            'label_omise_pkey'          => $this->language->get('label_omise_pkey'),
-            'label_omise_skey'          => $this->language->get('label_omise_skey'),
-            'label_omise_mode_test'     => $this->language->get('label_omise_mode_test'),
-            'label_omise_mode_live'     => $this->language->get('label_omise_mode_live'),
-            'label_omise_3ds'           => $this->language->get('label_omise_3ds'),
-            'label_omise_payment_title' => $this->language->get('label_omise_payment_title'),
-            'transfer_url'              => $this->url->link('payment/omise/submittransfer', 'token=' . $this->session->data['token'], 'SSL'),
-            'versioncheckup_url'        => $this->url->link('payment/omise/ajaxversioncheckup', 'token=' . $this->session->data['token'], 'SSL'),
-        ));
-
-        // Page templates
-        $data = array_merge($data, array(
-            'header'      => $this->load->controller('common/header'),
-            'breadcrumbs' => $this->_setBreadcrumb(null),
-            'column_left' => $this->load->controller('common/column_left'),
-            'footer'      => $this->load->controller('common/footer')
-        ));
-
-        $this->response->setOutput($this->load->view('payment/omise.tpl', $data));
+        return "";
     }
 
     /**
-     * Submit a `transfer` request to Omise server
-     * @return void
+     * @return string
      */
-    public function submitTransfer() {
-        $this->load->model('payment/omise');
-        $this->load->language('payment/omise');
+    private function flashErrorMessages() {
+        if (isset($this->session->data['error'])) {
+            $msg = $this->session->data['error'];
+            unset($this->session->data['error']);
 
-        try {
-            // POST request handler.
-            if (!$this->request->server['REQUEST_METHOD'] == 'POST')
-                throw new Exception($this->language->get('error_needed_post_request'), 1);
-
-            if (!isset($this->request->post['transfer_amount']))
-                throw new Exception($this->language->get('error_need_amount_value'), 1);
-
-            $transferring = $this->model_payment_omise->createOmiseTransfer($this->request->post['transfer_amount']);
-            if (isset($transferring['error']))
-                throw new Exception('Omise Transfer:: '.$transferring['error'], 1);
-            else
-                $this->session->data['success'] = $this->language->get('api_transfer_success');
-        } catch (Exception $e) {
-            $this->session->data['error'] = $e->getMessage();
+            return $msg;
         }
-        
-        $this->response->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
+
+        return "";
     }
 
     /**
      * Set page breadcrumb
-     * @return self
+     * @return array
      */
-    private function _setBreadcrumb($current = null) {
+    private function setBreadcrumb($current = null) {
         $this->load->language('payment/omise');
 
         // Set Breadcrumbs.
@@ -231,20 +57,238 @@ class ControllerPaymentOmise extends Controller {
 
         $breadcrumbs[] = array(
             'text'      => $this->language->get('heading_title'),
-            'href'      => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),             
+            'href'      => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),
             'separator' => ' :: '
         );
 
-        if (!is_null($current)) {
+        if (! is_null($current))
             $breadcrumbs[] = $current;
-        }
 
         return $breadcrumbs;
     }
 
     /**
+     * @return array
+     */
+    private function pageDataDashboardTab() {
+        $this->load->language('payment/omise');
+        $this->load->library('omise');
+        $this->load->model('localisation/currency');
+        $this->load->model('payment/omise');
+
+        $data = array();
+        $data['omise_dashboard'] = array(
+            'enabled' => $this->config->get('omise_status'),
+            'error'   => '',
+            'warning' => '',
+        );
+
+        if (! $data['omise_dashboard']['enabled']) {
+            $data['omise_dashboard']['error'][] = $this->language->get('error_extension_disabled');
+        } else {
+            try {
+                // Retrieve Omise Account.
+                $omise_account = $this->model_payment_omise->getOmiseAccount();
+                if (isset($omise_account['error']))
+                    throw new Exception('Omise Account:: '.$omise_account['error'], 1);
+
+                // Retrieve Omise Balance.
+                $omise_balance = $this->model_payment_omise->getOmiseBalance();
+                if (isset($omise_balance['error']))
+                    throw new Exception('Omise Balance:: '.$omise_balance['error'], 1);
+
+                // Retrieve Omise Charge List.
+                $omise_charge = $this->model_payment_omise->getOmiseChargeList();
+                if (isset($omise_charge['error']))
+                    throw new Exception('Omise Charge:: '.$omise_charge['error'], 1);
+
+                // Retrieve Omise Transfer List.
+                $omise_transfer = $this->model_payment_omise->getOmiseTransferList();
+                if (isset($omise_transfer['error']))
+                    throw new Exception('Omise Transfer:: '.$omise_transfer['error'], 1);
+
+                $data['omise_dashboard'] = array_merge(
+                    $data['omise_dashboard'],
+                    array(
+                        'email'          => $omise_account['email'],
+                        'created'        => $omise_account['created'],
+                        'livemode'       => $omise_balance['livemode'],
+                        'currency'       => $omise_balance['currency'],
+                        'available'      => $omise_balance['available'],
+                        'total'          => $omise_balance['total'],
+                        'charge_data'    => $omise_charge['data'],
+                        'charge_total'   => $omise_charge['total'],
+                        'transfer_data'  => $omise_transfer['data'],
+                        'transfer_total' => $omise_transfer['total'],
+                    )
+                );
+            } catch (Exception $e) {
+                $data['omise_dashboard']['error'][] = $e->getMessage();
+            }
+        }
+
+        // Check currency supports
+        if (! OmisePluginHelperCurrency::isSupport($this->config->get('config_currency'))) {
+            // THB currency
+            if (empty($this->model_localisation_currency->getCurrencyByCode('THB')))
+                $data['omise_dashboard']['warning'][] = $this->language->get('error_currency_thb_not_found').' <a href="'.$this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL').'">setup</a> or <a href="http://docs.opencart.com/system/localisation/currency">learn more</a>';
+
+            // JPY currency
+            if (empty($this->model_localisation_currency->getCurrencyByCode('JPY')))
+                $data['omise_dashboard']['warning'][] = $this->language->get('error_currency_jpy_not_found').' <a href="'.$this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL').'">setup</a> or <a href="http://docs.opencart.com/system/localisation/currency">learn more</a>';
+
+            $data['omise_dashboard']['warning'][] = $this->language->get('error_currency_no_support').' Your default currency is <strong>'.$this->config->get('config_currency').'</strong>.'.' <a href="'.$this->url->link('setting/store', 'token=' . $this->session->data['token'], 'SSL').'">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array
+     */
+    private function pageDataSettingTab() {
+        return array(
+            'omise_status'        => $this->config->get('omise_status'),
+            'omise_test_mode'     => $this->config->get('omise_test_mode'),
+            'omise_3ds'           => $this->config->get('omise_3ds'),
+            'omise_pkey_test'     => $this->config->get('omise_pkey_test'),
+            'omise_skey_test'     => $this->config->get('omise_skey_test'),
+            'omise_pkey'          => $this->config->get('omise_pkey'),
+            'omise_skey'          => $this->config->get('omise_skey'),
+            'omise_payment_title' => $this->config->get('omise_payment_title'),
+        );
+    }
+
+    /**
+     * This method will fire when user click `install` button from `extension/payment` page
+     * It will call `model/payment/omise.php` file and run `install` method for installl stuff
+     * that necessary to use in Omise Payment Gateway module
+     * @return void
+     */
+    public function install() {
+        $this->load->model('payment/omise');
+
+        try {
+            // Install the extension
+            if (! $this->model_payment_omise->install())
+                throw new Exception('', 1);
+        } catch (Exception $e) {
+            // Uninstall
+            $this->load->controller('extension/payment/uninstall');
+        }
+    }
+
+    /**
+     * This method will fire when user click `Uninstall` button from `extension/payment` page
+     * Uninstall everything that related with Omise Payment Gateway module.
+     * @return void
+     */
+    public function uninstall() {
+
+    }
+
+    /**
+     * (GET) Page, route=payment/omise
+     */
+    public function index() {
+        // POST Request handle
+        if (($this->request->server['REQUEST_METHOD'] == 'POST'))
+            $this->updateConfig();
+
+        $this->load->language('payment/omise');
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        // Manipulate page's data
+        $data = array_merge(
+            $this->pageDataDashboardTab(),
+            $this->pageDataSettingTab(),
+            array(
+                'success'                   => $this->flashSuccessMessages(),
+                'error_warning'             => $this->flashErrorMessages(),
+                'heading_title'             => $this->language->get('heading_title'),
+                'button_save'               => $this->language->get('button_save'),
+                'action'                    => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),
+                'button_cancel'             => $this->language->get('button_cancel'),
+                'cancel'                    => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
+                'text_form'                 => $this->language->get('text_form'),
+                'entry_status'              => $this->language->get('entry_status'),
+                'text_enabled'              => $this->language->get('text_enabled'),
+                'text_disabled'             => $this->language->get('text_disabled'),
+                'label_omise_pkey_test'     => $this->language->get('label_omise_pkey_test'),
+                'label_omise_skey_test'     => $this->language->get('label_omise_skey_test'),
+                'label_omise_pkey'          => $this->language->get('label_omise_pkey'),
+                'label_omise_skey'          => $this->language->get('label_omise_skey'),
+                'label_omise_mode_test'     => $this->language->get('label_omise_mode_test'),
+                'label_omise_mode_live'     => $this->language->get('label_omise_mode_live'),
+                'label_omise_3ds'           => $this->language->get('label_omise_3ds'),
+                'label_omise_payment_title' => $this->language->get('label_omise_payment_title'),
+                'transfer_url'              => $this->url->link('payment/omise/submittransfer', 'token=' . $this->session->data['token'], 'SSL'),
+                'versioncheckup_url'        => $this->url->link('payment/omise/ajaxversioncheckup', 'token=' . $this->session->data['token'], 'SSL'),
+            )
+        );
+
+        // Page templates
+        $data = array_merge($data, array(
+            'header'      => $this->load->controller('common/header'),
+            'breadcrumbs' => $this->setBreadcrumb(null),
+            'column_left' => $this->load->controller('common/column_left'),
+            'footer'      => $this->load->controller('common/footer')
+        ));
+
+        $this->response->setOutput($this->load->view('payment/omise.tpl', $data));
+    }
+
+    /**
+     * (POST)
+     * @return void
+     */
+    public function updateConfig() {
+        $this->load->model('setting/setting');
+        $this->load->language('payment/omise');
+
+        $update = $this->request->post;
+        if (! empty($update)) {
+            $update['omise_3ds'] = isset($update['omise_3ds']) ? $update['omise_3ds'] : 0;
+
+            // Update
+            $this->model_setting_setting->editSetting('omise', $update);
+
+            $this->session->data['success'] = $this->language->get('text_session_save');
+            $this->response->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
+        }
+    }
+
+    /**
+     * Submit a transfer request to Omise server
+     * @return void
+     */
+    public function submitTransfer() {
+        $this->load->model('payment/omise');
+        $this->load->language('payment/omise');
+
+        try {
+            // POST request handler.
+            if (! $this->request->server['REQUEST_METHOD'] === 'POST')
+                throw new Exception($this->language->get('error_needed_post_request'), 1);
+
+            if (! isset($this->request->post['transfer_amount']) || $this->request->post['transfer_amount'] <= 0)
+                throw new Exception($this->language->get('error_need_amount_value'), 1);
+
+            $transferring = $this->model_payment_omise->createOmiseTransfer($this->request->post['transfer_amount']);
+            if (isset($transferring['error']))
+                throw new Exception('Omise Transfer:: '.$transferring['error'], 1);
+
+            $this->session->data['success'] = $this->language->get('api_transfer_success');
+        } catch (Exception $e) {
+            $this->session->data['error'] = $e->getMessage();
+        }
+
+        $this->response->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
+    }
+
+    /**
      * Get the latest version number of Omise-OpenCart from Github.
-     * @return Json
+     * @return string (json)
      */
     public function ajaxVersionCheckup() {
         $this->load->library('omise');

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -50,8 +50,9 @@ $_['api_transfer_success']      = 'Your transfer request has sent already.';
  */
 $_['error_omise_table_install_failed']  = 'Can not create Omise table now, something wrong.';
 $_['error_extension_disabled']          = 'Please enable Omise Payment Gateway extension (check \'Setting\' tab).';
-$_['error_currency_thb_not_found']      = 'Thai Baht (THB) currency was not found from your system.';
-$_['error_currency_no_support']         = 'Currently, we only support Thai Baht (THB).';
+$_['error_currency_thb_not_found']      = 'Thai Baht (THB) currencies was not found from your system.';
+$_['error_currency_jpy_not_found']      = 'Japanese Yen (JPY) currencies was not found from your system.';
+$_['error_currency_no_support']         = 'Currently, we only support Thai Baht (THB) and Japanese Yen (JPY).';
 // $_['error_omise_menu_xml_not_exists']   = 'omise_menu.xml not found in install folder, please check.';
 // $_['error_vqmod_xml_not_exists']        = 'vQmod\'s xml folder does not exists.';
 // $_['error_file_not_writable']           = 'File not writable, please give it the writable permission.';

--- a/src/admin/view/template/payment/omise.tpl
+++ b/src/admin/view/template/payment/omise.tpl
@@ -56,9 +56,9 @@ echo $header; ?><?php echo $column_left; ?>
     <div class="tab-content">
       <!-- Dashboard tab -->
       <div class="tab-pane active in" id="tab-dashboard">
-        <?php if ($omise_dashboard['error_danger']) { ?>
-          <?php if (is_array($omise_dashboard['error_danger'])) { ?>
-              <?php foreach ($omise_dashboard['error_danger'] as $key => $value) { ?>
+        <?php if ($omise_dashboard['error']) { ?>
+          <?php if (is_array($omise_dashboard['error'])) { ?>
+              <?php foreach ($omise_dashboard['error'] as $key => $value) { ?>
                 <div class="alert alert-danger">
                   <i class="fa fa-exclamation-circle"></i>
                   <?php echo $value; ?>
@@ -68,17 +68,17 @@ echo $header; ?><?php echo $column_left; ?>
           <?php } else { ?>
             <div class="alert alert-danger">
               <i class="fa fa-exclamation-circle"></i>
-              <?php echo $omise_dashboard['error_danger']; ?>
+              <?php echo $omise_dashboard['error']; ?>
               <button type="button" class="close" data-dismiss="alert">&times;</button>
             </div>
           <?php } ?>
         <?php } ?>
 
-        <?php if ($omise_dashboard['enabled'] && !$omise_dashboard['error_danger']) { ?>
+        <?php if ($omise_dashboard['enabled'] && !$omise_dashboard['error']) { ?>
 
-          <?php if ($omise_dashboard['error_warning']) { ?>
-            <?php if (is_array($omise_dashboard['error_warning'])) { ?>
-                <?php foreach ($omise_dashboard['error_warning'] as $key => $value) { ?>
+          <?php if ($omise_dashboard['warning']) { ?>
+            <?php if (is_array($omise_dashboard['warning'])) { ?>
+                <?php foreach ($omise_dashboard['warning'] as $key => $value) { ?>
                   <div class="alert alert-warning">
                     <i class="fa fa-exclamation-circle"></i>
                     <?php echo $value; ?>
@@ -88,7 +88,7 @@ echo $header; ?><?php echo $column_left; ?>
             <?php } else { ?>
               <div class="alert alert-warning">
                 <i class="fa fa-exclamation-circle"></i>
-                <?php echo $omise_dashboard['error_warning']; ?>
+                <?php echo $omise_dashboard['warning']; ?>
                 <button type="button" class="close" data-dismiss="alert">&times;</button>
               </div>
             <?php } ?>
@@ -101,22 +101,22 @@ echo $header; ?><?php echo $column_left; ?>
                 <dl>
                   <!-- Account email -->
                   <dt>Account: </dt>
-                  <dd><?php echo $omise_dashboard['account']['email']; ?></dd>
+                  <dd><?php echo $omise_dashboard['email']; ?></dd>
 
                   <!-- Account status -->
                   <dt>Mode: </dt>
-                  <dd><strong><?php echo $omise_dashboard['balance']['livemode'] ? '<span class="livemode-label">Live</span>' : '<span class="testmode-label">Test</span>'; ?></strong></dd>
+                  <dd><strong><?php echo $omise_dashboard['livemode'] ? '<span class="livemode-label">Live</span>' : '<span class="testmode-label">Test</span>'; ?></strong></dd>
 
                   <!-- Current Currency -->
                   <dt>Currency: </dt>
-                  <dd><?php echo strtoupper($omise_dashboard['balance']['currency']); ?></dd>
+                  <dd><?php echo strtoupper($omise_dashboard['currency']); ?></dd>
                 </dl>
               </div>
 
               <!-- Balance -->
               <div class="omise-balance omise-clearfix">
-                <div class="left"><span class="omise-number"><?php echo number_format(($omise_dashboard['balance']['total']/100), 2); ?> ฿</span><br/>Total Balance</div>
-                <div class="right"><span class="omise-number"><?php echo number_format(($omise_dashboard['balance']['available']/100), 2); ?> ฿</span><br/>Transferable Balance</div>
+                <div class="left"><span class="omise-number"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $omise_dashboard['total']); ?></span><br/>Total Balance</div>
+                <div class="right"><span class="omise-number"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $omise_dashboard['available']); ?></span><br/>Transferable Balance</div>
               </div>
 
               <!-- Charge History -->
@@ -148,10 +148,10 @@ echo $header; ?><?php echo $column_left; ?>
                               </tr>
                             </thead>
                             <tbody>
-                              <?php foreach ($omise_dashboard['charge']['data'] as $key => $value): $date = new \DateTime($value['created']); ?>
+                              <?php foreach ($omise_dashboard['charge_data'] as $key => $value): $date = new \DateTime($value['created']); ?>
                                 <tr>
-                                  <td><?php echo $omise_dashboard['charge']['total'] -$key; ?></td>
-                                  <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['authorized'] || !$value['captured']) ? 'text-warning' : 'text-success'); ?>"><?php echo number_format(($value['amount']/100), 2); ?> ฿</strong></td>
+                                  <td><?php echo $omise_dashboard['charge_total'] -$key; ?></td>
+                                  <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['authorized'] || !$value['captured']) ? 'text-warning' : 'text-success'); ?>"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $value['amount']); ?></strong></td>
                                   <td><a href="https://dashboard.omise.co/<?php echo $value['livemode'] ? 'live' : 'test'; ?>/charges/<?php echo $value['id']; ?>"><?php echo $value['id']; ?></a></td>
                                   <td><?php echo $value['authorized'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>
                                   <td><?php echo $value['captured'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>
@@ -183,10 +183,10 @@ echo $header; ?><?php echo $column_left; ?>
                               </tr>
                             </thead>
                             <tbody>
-                              <?php foreach ($omise_dashboard['transfer']['data'] as $key => $value): $date = new \DateTime($value['created']); ?>
+                              <?php foreach ($omise_dashboard['transfer_data'] as $key => $value): $date = new \DateTime($value['created']); ?>
                                 <tr>
-                                  <td><?php echo $omise_dashboard['transfer']['total'] -$key; ?></td>
-                                  <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['sent'] || !$value['paid']) ? 'text-warning' : 'text-success'); ?>"><?php echo number_format(($value['amount']/100), 2); ?> ฿</strong></td>
+                                  <td><?php echo $omise_dashboard['transfer_total'] -$key; ?></td>
+                                  <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['sent'] || !$value['paid']) ? 'text-warning' : 'text-success'); ?>"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $value['amount']); ?></strong></td>
                                   <td><a href="https://dashboard.omise.co/<?php echo $value['livemode'] ? 'live' : 'test'; ?>/transfers//<?php echo $value['id']; ?>"><?php echo $value['id']; ?></a></td>
                                   <td><?php echo $value['sent'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>
                                   <td><?php echo $value['paid'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -58,7 +58,7 @@ class ControllerPaymentOmise extends Controller {
 					$omise_charge = OmiseCharge::create(
 						array(
 							"amount"        => $order_total,
-							"currency"      => 'thb',
+							"currency"      => $this->currency->getCode(),
 							"description"   => $this->request->post['description'],
 							"return_uri"	=> $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
 							"card"          => $this->request->post['omise_token']

--- a/src/system/library/omise-plugin/helpers/currency.php
+++ b/src/system/library/omise-plugin/helpers/currency.php
@@ -1,0 +1,43 @@
+<?php
+
+class OmisePluginHelperCurrency
+{
+    /**
+     * @param string $currency_code
+     */
+    public static function isSupport($currency_code) {
+        switch (strtoupper($currency_code)) {
+            case 'THB':
+            case 'JPY':
+                return true;
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string  $currency
+     * @param integer $amount
+     */
+    public static function format($currency, $amount) {
+        switch (strtoupper($currency)) {
+            case 'THB':
+                $amount = "฿" . number_format(($amount / 100), 2);
+                if (preg_match('/\.00$/', $amount)) {
+                    $amount = substr($amount, 0, -3);
+                }
+
+                break;
+
+            case 'JPY':
+                $amount = "¥" . number_format($amount);
+                break;
+
+            default:
+                break;
+        }
+
+        return $amount;
+    }
+}

--- a/src/system/library/omise.php
+++ b/src/system/library/omise.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once dirname(__FILE__).'/omise-plugin/helpers/currency.php';
+
 // Define version of Omise-OpenCart
 if (!defined('OMISE_OPENCART_VERSION'))
     define('OMISE_OPENCART_VERSION', '2.0.0.0');
@@ -18,4 +21,5 @@ if (!defined('OMISE_USER_AGENT_SUFFIX'))
 // Define 'OMISE_API_VERSION'
 if(!defined('OMISE_API_VERSION'))
     define('OMISE_API_VERSION', '2014-07-27');
+
 ?>


### PR DESCRIPTION
#### 1. Objective reason

This PR contains main 3 things,
1. Support JPY currency (both Omise admin dashboard and checkout page)
2. Refactoring & clean code
3. Introduced `Omise-Plugin` library, it contains necessary classes, files that we always used in every of our plugins. So, instead of implement classes, helper methods repeatedly every time we integrate, just copy this one and use everywhere.

and few changes,
1. Refactoring & clean code
2. Improved code, translation, code comment, etc.

#### 2. Description of change

1. Updated Omise Dashboard to support JPY currency
  <img width="1114" alt="screen shot 2559-05-19 at 2 20 30 am" src="https://cloud.githubusercontent.com/assets/2154669/15371976/540e902c-1d68-11e6-8f56-2acb8ce69955.png">
2. Could proceed payment with JPY currency!


#### 3. Developers affected by the change

`-`

#### 4. Impact of the change

`-`

#### 5. Priority of change

:star2: :star2: :star2:

#### 6. Alternate solution (if any)**

`-`

noted: JP translation, UI improvement are coming very soon (next PR)