### PR TITLE
Implement a feature, manual capture

### DIFF
--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -152,7 +152,7 @@ class ControllerPaymentOmise extends Controller {
         $this->load->model('payment/omise');
 
     	if (is_null($this->config->get('omise_auto_capture'))) {
-    		$omise_auto_capture = $this->model_payment_omise->get_default_auto_capture();
+    		$omise_auto_capture = $this->model_payment_omise->getDefaultAutoCapture();
     	} else {
     		$omise_auto_capture = $this->config->get('omise_auto_capture');
     	}

--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -158,6 +158,7 @@ class ControllerPaymentOmise extends Controller {
             'omise_pkey'          => $this->config->get('omise_pkey'),
             'omise_skey'          => $this->config->get('omise_skey'),
             'omise_payment_title' => $this->config->get('omise_payment_title'),
+            'omise_auto_capture'  => $this->config->get('omise_auto_capture')
         );
     }
 
@@ -207,12 +208,15 @@ class ControllerPaymentOmise extends Controller {
             'label_omise_mode_live'                   => $this->language->get('label_omise_mode_live'),
             'label_omise_3ds'                         => $this->language->get('label_omise_3ds'),
             'label_omise_payment_title'               => $this->language->get('label_omise_payment_title'),
+            'label_omise_payment_action'              => $this->language->get('label_omise_payment_action'),
             'text_mode_test'                          => $this->language->get('text_mode_test'),
             'text_mode_live'                          => $this->language->get('text_mode_live'),
             'text_enabled'                            => $this->language->get('text_enabled'),
             'text_disabled'                           => $this->language->get('text_disabled'),
             'text_checking_for_latest_version'        => $this->language->get('text_checking_for_latest_version'),
             'text_version_up_to_date'                 => $this->language->get('text_version_up_to_date'),
+            'text_auto_capture'                       => $this->language->get('text_auto_capture'),
+            'text_manual_capture'                     => $this->language->get('text_manual_capture'),
             'button_save'                             => $this->language->get('button_save'),
             'button_cancel'                           => $this->language->get('button_cancel'),
             'button_create_transfer'                  => $this->language->get('button_create_transfer'),

--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -149,6 +149,14 @@ class ControllerPaymentOmise extends Controller {
      * @return array
      */
     private function pageDataSettingTab() {
+        $this->load->model('payment/omise');
+
+    	if (is_null($this->config->get('omise_auto_capture'))) {
+    		$omise_auto_capture = $this->model_payment_omise->get_default_auto_capture();
+    	} else {
+    		$omise_auto_capture = $this->config->get('omise_auto_capture');
+    	}
+
         return array(
             'omise_status'        => $this->config->get('omise_status'),
             'omise_test_mode'     => $this->config->get('omise_test_mode'),
@@ -158,7 +166,7 @@ class ControllerPaymentOmise extends Controller {
             'omise_pkey'          => $this->config->get('omise_pkey'),
             'omise_skey'          => $this->config->get('omise_skey'),
             'omise_payment_title' => $this->config->get('omise_payment_title'),
-            'omise_auto_capture'  => $this->config->get('omise_auto_capture')
+            'omise_auto_capture'  => $omise_auto_capture
         );
     }
 

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -46,6 +46,7 @@ $_['label_omise_pkey']                                         = 'Public Key';
 $_['label_omise_skey']                                         = 'Secret Key';
 $_['label_omise_3ds']                                          = 'Enable 3D-Secure';
 $_['label_omise_payment_title']                                = 'Payment method title';
+$_['label_omise_payment_action']                               = 'Payment Action';
 
 
 // Breadcrumb menu.
@@ -62,6 +63,8 @@ $_['text_checking_for_latest_version']                         = 'Checking for l
 $_['text_version_up_to_date']                                  = 'Your Omise-OpenCart version is up to date.';
 $_['text_session_save']                                        = 'Saved.';
 $_['text_omise_transfer_success']                              = 'Your transfer request has sent already.';
+$_['text_auto_capture']                                        = 'Auto Capture';
+$_['text_manual_capture']                                      = 'Manual Capture';
 
 
 // Action buttons

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -34,7 +34,7 @@ $_['label_transfer_amount_field_placeholder']                  = 'Transfer amoun
 $_['label_setting_module_config']                              = 'Module Config';
 $_['label_setting_module_status']                              = 'Module Status';
 $_['label_setting_key_config']                                 = 'Omise Keys Config';
-$_['label_setting_omise_config']                               = 'Omise Advance Integration';
+$_['label_setting_omise_config']                               = 'Omise Advance Settings';
 
 
 // Omise's labels
@@ -62,7 +62,7 @@ $_['text_disabled']                                            = 'Disabled';
 $_['text_checking_for_latest_version']                         = 'Checking for latest version...';
 $_['text_version_up_to_date']                                  = 'Your Omise-OpenCart version is up to date.';
 $_['text_session_save']                                        = 'Saved.';
-$_['text_omise_transfer_success']                              = 'Your transfer request has sent already.';
+$_['text_omise_transfer_success']                              = 'Your transfer request has been sent already.';
 $_['text_auto_capture']                                        = 'Auto Capture';
 $_['text_manual_capture']                                      = 'Manual Capture';
 

--- a/src/admin/language/japanese/payment/omise.php
+++ b/src/admin/language/japanese/payment/omise.php
@@ -46,6 +46,7 @@ $_['label_omise_pkey']                                         = 'パブリッ�
 $_['label_omise_skey']                                         = 'シークレットキー';
 $_['label_omise_3ds']                                          = '3Dセキュアの有効化';
 $_['label_omise_payment_title']                                = '決済方法';
+$_['label_omise_payment_action']                               = '売上処理方法';
 
 
 // Breadcrumb menu.
@@ -62,6 +63,8 @@ $_['text_checking_for_latest_version']                         = '最新のバ�
 $_['text_version_up_to_date']                                  = 'お使いの Omise-OpenCart のバージョンは最新です';
 $_['text_session_save']                                        = '保存されました';
 $_['text_omise_transfer_success']                              = '振込要求が送信されました';
+$_['text_auto_capture']                                        = '自動売上';
+$_['text_manual_capture']                                      = '手動売上';
 
 
 // Action buttons

--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -20,7 +20,8 @@ class ModelPaymentOmise extends Model {
             'omise_skey_test'     => '',
             'omise_test_mode'     => 0,
             'omise_3ds'           => 0,
-            'omise_payment_title' => 'Credit Card (Powered by Omise)'
+            'omise_payment_title' => 'Credit Card (Powered by Omise)',
+            'omise_auto_capture'  => 1
         ));
 
         /* Install omise_charge table */

--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -5,6 +5,14 @@ class ModelPaymentOmise extends Model {
      */
     private $_table = 'omise_gateway';
     private $_group = 'omise';
+    
+    /**
+     * 0 is manual capture.
+     * 1 is auto capture.
+     * 
+     * @var integer
+     */
+    const DEFAULT_AUTO_CAPTURE = 1;
 
     /**
      * Install a table that need to use in Omise Payment Gateway module
@@ -21,7 +29,7 @@ class ModelPaymentOmise extends Model {
             'omise_test_mode'     => 0,
             'omise_3ds'           => 0,
             'omise_payment_title' => 'Credit Card (Powered by Omise)',
-            'omise_auto_capture'  => 1
+            'omise_auto_capture'  => self::DEFAULT_AUTO_CAPTURE
         ));
 
         /* Install omise_charge table */
@@ -201,5 +209,9 @@ class ModelPaymentOmise extends Model {
         }
 
         return $keys;
+    }
+    
+    public function get_default_auto_capture() {
+    	return self::DEFAULT_AUTO_CAPTURE;
     }
 }

--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -211,7 +211,7 @@ class ModelPaymentOmise extends Model {
         return $keys;
     }
     
-    public function get_default_auto_capture() {
+    public function getDefaultAutoCapture() {
     	return self::DEFAULT_AUTO_CAPTURE;
     }
 }

--- a/src/admin/view/template/payment/omise.tpl
+++ b/src/admin/view/template/payment/omise.tpl
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Include header.
  *
@@ -12,7 +12,7 @@ echo $header; ?><?php echo $column_left; ?>
         <button type="submit" onclick="$('#form-setting').submit();" data-toggle="tooltip" title="<?php echo $button_save; ?>" class="btn btn-primary"><i class="fa fa-save"></i></button>
         <a href="<?php echo $cancel; ?>" data-toggle="tooltip" title="<?php echo $button_cancel; ?>" class="btn btn-default"><i class="fa fa-reply"></i></a>
       </div>
-      
+
       <h1><?php echo $heading_title; ?></h1>
       <ul class="breadcrumb">
         <?php foreach ($breadcrumbs as $breadcrumb) { ?>
@@ -307,11 +307,21 @@ echo $header; ?><?php echo $column_left; ?>
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="omise_payments_3ds"><?php echo $label_omise_3ds; ?></label>
                 <div class="col-sm-10">
-                  <div class="checkbox">
-                    <input type="checkbox" name="omise_3ds" value="1" class="form-control" <?php echo $omise_3ds ? 'checked="checked"' : ''; ?> />
+                  <div class="checkbox-inline">
+                    <input type="checkbox" name="omise_3ds" id="omise_payments_3ds" value="1" class="form-control" <?php echo $omise_3ds ? 'checked="checked"' : ''; ?> />
                   </div>
                 </div>
               </div> <!-- /END .3D-Secure -->
+              <!-- Payment Action -->
+              <div class="form-group">
+                <label class="col-sm-2 control-label" for="omise_auto_capture"><?php echo $label_omise_payment_action; ?></label>
+                <div class="col-sm-10">
+                  <select name="omise_auto_capture" id="omise_auto_capture" class="form-control">
+                    <option value="1" <?php echo $omise_auto_capture ? 'selected="selected"' : ''; ?>><?php echo $text_auto_capture; ?></option>
+                    <option value="0" <?php echo !$omise_auto_capture ? 'selected="selected"' : ''; ?>><?php echo $text_manual_capture; ?></option>
+                  </select>
+                </div>
+              </div> <!-- /END Payment Action -->
             </div>
           </div>
         </form>
@@ -332,7 +342,7 @@ echo $header; ?><?php echo $column_left; ?>
       </div>
     </div>
 
-    
+
   </div> <!-- /END .container-fluid -->
 </div> <!-- /END #content -->
 

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -62,12 +62,6 @@ class ControllerPaymentOmise extends Controller {
 				$omise['skey'] = $this->config->get('omise_skey');
 			}
 
-			if ($this->config->get('omise_auto_capture') == 0) {
-				$omise['capture'] = false;
-			} else {
-				$omise['capture'] = true;
-			}
-
 			// Create a order history with `Processing` status
 			$order_id    = $this->session->data['order_id'];
 			$order_info  = $this->model_checkout_order->getOrder($order_id);
@@ -82,7 +76,7 @@ class ControllerPaymentOmise extends Controller {
 							"description" => $this->request->post['description'],
 							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
 							"card"        => $this->request->post['omise_token'],
-							"capture"     => $omise['capture']
+							"capture"     => $this->config->get('omise_auto_capture')
 						),
 						$omise['pkey'],
 						$omise['skey']

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -62,6 +62,12 @@ class ControllerPaymentOmise extends Controller {
 				$omise['skey'] = $this->config->get('omise_skey');
 			}
 
+			if ($this->config->get('omise_auto_capture') == 0) {
+				$omise['capture'] = false;
+			} else {
+				$omise['capture'] = true;
+			}
+
 			// Create a order history with `Processing` status
 			$order_id    = $this->session->data['order_id'];
 			$order_info  = $this->model_checkout_order->getOrder($order_id);
@@ -75,7 +81,8 @@ class ControllerPaymentOmise extends Controller {
 							"currency"    => $this->currency->getCode(),
 							"description" => $this->request->post['description'],
 							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
-							"card"        => $this->request->post['omise_token']
+							"card"        => $this->request->post['omise_token'],
+							"capture"     => $omise['capture']
 						),
 						$omise['pkey'],
 						$omise['skey']


### PR DESCRIPTION
**1. Objective reason**

Add a feature, manual capture. The OpenCart administrator can configures whether auto or manual capture the charge.

Related ticket: T307

**2. Description of change**

- The configuration is displayed at the Setting tab, Omise Advance Settings box. The example image below.
![opencart_omise_payment_action_auto_manual_capture](https://cloud.githubusercontent.com/assets/4145121/15958461/0099c8ac-2f20-11e6-8e6e-3a023329a143.png)

- Japanese language supported
![opencart_omise_payment_action_japanese](https://cloud.githubusercontent.com/assets/4145121/15956883/a0f39464-2f15-11e6-9e0f-f8f31cab98b3.png)

- If Payment Action was changed to be Manual Capture, the charge will be not captured. The data at a column, Paid, will be displayed as No. The example image below.
![opencart_omise_manual_capture_charge](https://cloud.githubusercontent.com/assets/4145121/15956887/a8f91972-2f15-11e6-8873-0949baaf064d.png)

To manually capture the payment, click the Charge Id and proceed the capture on Omise Dashboard normally.

**3. Users affected by the change**

`-`

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`