### PR TITLE
Remove a column, No., from Charge and Transfer list

### DIFF
--- a/src/admin/view/template/payment/omise.tpl
+++ b/src/admin/view/template/payment/omise.tpl
@@ -138,7 +138,6 @@ echo $header; ?><?php echo $column_left; ?>
                           <table class="table table-bordered table-hover table-striped">
                             <thead>
                               <tr>
-                                <td><?php echo $label_charge_table_no; ?></td>
                                 <td><?php echo $label_charge_table_amount; ?></td>
                                 <td><?php echo $label_charge_table_id; ?></td>
                                 <td width="8%"><?php echo $label_charge_table_authorized; ?></td>
@@ -150,7 +149,6 @@ echo $header; ?><?php echo $column_left; ?>
                             <tbody>
                               <?php foreach ($omise_dashboard['charge_data'] as $key => $value): $date = new \DateTime($value['created']); ?>
                                 <tr>
-                                  <td><?php echo $omise_dashboard['charge_total'] -$key; ?></td>
                                   <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['authorized'] || !$value['captured']) ? 'text-warning' : 'text-success'); ?>"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $value['amount']); ?></strong></td>
                                   <td><a href="https://dashboard.omise.co/<?php echo $value['livemode'] ? 'live' : 'test'; ?>/charges/<?php echo $value['id']; ?>"><?php echo $value['id']; ?></a></td>
                                   <td><?php echo $value['authorized'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>
@@ -173,7 +171,6 @@ echo $header; ?><?php echo $column_left; ?>
                           <table class="table table-bordered table-hover">
                             <thead>
                               <tr>
-                                <td><?php echo $label_transfer_table_no; ?></td>
                                 <td><?php echo $label_transfer_table_amount; ?></td>
                                 <td><?php echo $label_transfer_table_id; ?></td>
                                 <td><?php echo $label_transfer_table_sent; ?></td>
@@ -185,7 +182,6 @@ echo $header; ?><?php echo $column_left; ?>
                             <tbody>
                               <?php foreach ($omise_dashboard['transfer_data'] as $key => $value): $date = new \DateTime($value['created']); ?>
                                 <tr>
-                                  <td><?php echo $omise_dashboard['transfer_total'] -$key; ?></td>
                                   <td><strong class="<?php echo ($value['failure_code']) ? 'text-danger' : ((!$value['sent'] || !$value['paid']) ? 'text-warning' : 'text-success'); ?>"><?php echo OmisePluginHelperCurrency::format($omise_dashboard['currency'], $value['amount']); ?></strong></td>
                                   <td><a href="https://dashboard.omise.co/<?php echo $value['livemode'] ? 'live' : 'test'; ?>/transfers//<?php echo $value['id']; ?>"><?php echo $value['id']; ?></a></td>
                                   <td><?php echo $value['sent'] ? '<strong class="text-success">Yes</strong>' : 'No'; ?></td>
@@ -195,7 +191,7 @@ echo $header; ?><?php echo $column_left; ?>
                                 </tr>
                               <?php endforeach; ?>
                               <tr>
-                                <td colspan="6" class="text-right"><input style="width: 25%; float:right;" class="form-control" min="0" type="number" step="0.01" name="transfer_amount" placeholder="<?php echo $label_transfer_amount_field_placeholder; ?>"></td>
+                                <td colspan="5" class="text-right"><input style="width: 25%; float:right;" class="form-control" min="0" type="number" step="0.01" name="transfer_amount" placeholder="<?php echo $label_transfer_amount_field_placeholder; ?>"></td>
                                 <td class="text-center">
                                   <button type="submit" id="button-transfer" class="btn btn-primary"><?php echo $button_create_transfer; ?>&nbsp;&nbsp;<i class="fa fa-chevron-right"></i></button>
                                 </td>


### PR DESCRIPTION
**1. Objective reason**

Remove a column, No., from Charge and Transfer List. To make the screen has consistency, looks similar with other plugins and Omise Dashboard, and remains the same user experience.

Additional information:
Before change, the data displayed in the column, No., is sorted by created date descending. When the data exceed the limit of the list, the display is quite confusing. The example image below.

![opencart-omise-charge-exceed-list](https://cloud.githubusercontent.com/assets/4145121/16002601/cb06a8da-3182-11e6-96fa-4b4b7e11aebb.png)

Related ticket: T449

**2. Description of change**

- A column, No., was removed from Charge list. The example image below.
![screen shot 2016-06-13 at 4 12 51 pm](https://cloud.githubusercontent.com/assets/4145121/16002453/ece963bc-3181-11e6-9cb1-07a3842d5020.png)

- A column, No., was removed from Transfer List. The example image below.
![screen shot 2016-06-13 at 4 13 14 pm](https://cloud.githubusercontent.com/assets/4145121/16002459/f5fc6594-3181-11e6-8955-e4e1fbfe8277.png)

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`