### PR TITLE
Format transfer amount

### DIFF
--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -168,25 +168,19 @@ class ModelPaymentOmise extends Model {
         $this->load->library('omise');
         $this->load->library('omise-php/lib/Omise');
         $this->load->language('payment/omise');
-        $this->load->model('payment/omise');
 
         // Get Omise Keys.
         if ($keys = $this->_retrieveOmiseKeys()) {
             try {
-                $omise_balance = $this->model_payment_omise->getOmiseBalance();
+                $omise_balance = $this->getOmiseBalance();
                 if (isset($omise_balance['error'])) {
                     throw new Exception('Omise Balance ' . $omise_balance['error'], 1);
                 }
 
                 $transfer_amount = OmisePluginHelperTransfer::amount($omise_balance['currency'], $amount);
 
-                $omise = OmiseTransfer::create(array('amount' => $transfer_amount), $keys['pkey'], $keys['skey']);
+                return OmiseTransfer::create(array('amount' => $transfer_amount), $keys['pkey'], $keys['skey']);
 
-                if (isset($omise['object']) && $omise['object'] == "transfer") {
-                    return true;
-                } else {
-                    return array('error' => 'Something went wrong.');
-                }
             } catch (Exception $e) {
                 return array('error' => $e->getMessage());
             }

--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -168,16 +168,25 @@ class ModelPaymentOmise extends Model {
         $this->load->library('omise');
         $this->load->library('omise-php/lib/Omise');
         $this->load->language('payment/omise');
+        $this->load->model('payment/omise');
 
         // Get Omise Keys.
         if ($keys = $this->_retrieveOmiseKeys()) {
             try {
-                $omise = OmiseTransfer::create(array('amount' => $amount), $keys['pkey'], $keys['skey']);
+                $omise_balance = $this->model_payment_omise->getOmiseBalance();
+                if (isset($omise_balance['error'])) {
+                    throw new Exception('Omise Balance ' . $omise_balance['error'], 1);
+                }
 
-                if (isset($omise['object']) && $omise['object'] == "transfer")
+                $transfer_amount = OmisePluginHelperTransfer::amount($omise_balance['currency'], $amount);
+
+                $omise = OmiseTransfer::create(array('amount' => $transfer_amount), $keys['pkey'], $keys['skey']);
+
+                if (isset($omise['object']) && $omise['object'] == "transfer") {
                     return true;
-                else
+                } else {
                     return array('error' => 'Something went wrong.');
+                }
             } catch (Exception $e) {
                 return array('error' => $e->getMessage());
             }

--- a/src/system/library/omise-plugin/helpers/transfer.php
+++ b/src/system/library/omise-plugin/helpers/transfer.php
@@ -1,0 +1,28 @@
+<?php
+if (! class_exists('OmisePluginHelperTransfer')) {
+	class OmisePluginHelperTransfer {
+		/**
+		 * Format the transfer amount into the appropriate format for each currency.
+		 * Now, only Thai Baht (THB) that need to format.
+		 *
+		 * Example for THB:
+		 * 100    => 10000
+		 * 100.25 => 10025
+		 * 100.50 => 10050
+		 * 100.1  => 10010
+		 *
+		 * @param string  $currency
+		 * @param integer $amount
+		 * @return string
+		 */
+		public static function amount($currency, $amount) {
+			switch (strtoupper($currency)) {
+				case 'THB':
+					$amount = $amount * 100;
+					break;
+			}
+
+			return $amount;
+		}
+	}
+}

--- a/src/system/library/omise-plugin/helpers/transfer.php
+++ b/src/system/library/omise-plugin/helpers/transfer.php
@@ -7,6 +7,7 @@ if (! class_exists('OmisePluginHelperTransfer')) {
 		 *
 		 * Example for THB:
 		 * 100    => 10000
+		 * 100.00 => 10000
 		 * 100.25 => 10025
 		 * 100.50 => 10050
 		 * 100.1  => 10010

--- a/src/system/library/omise.php
+++ b/src/system/library/omise.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__).'/omise-plugin/helpers/charge.php';
 require_once dirname(__FILE__).'/omise-plugin/helpers/currency.php';
+require_once dirname(__FILE__).'/omise-plugin/helpers/transfer.php';
 
 // Define version of Omise-OpenCart
 if (!defined('OMISE_OPENCART_VERSION'))
@@ -9,8 +10,8 @@ if (!defined('OMISE_OPENCART_VERSION'))
 
 // Just mockup
 $datetime = new DateTime('now');
-$datetime->format('Y-m-d\TH:i:s\Z'); 
-if (!defined('OMISE_OPENCART_RELEASED_DATE')) 
+$datetime->format('Y-m-d\TH:i:s\Z');
+if (!defined('OMISE_OPENCART_RELEASED_DATE'))
     define('OMISE_OPENCART_RELEASED_DATE', $datetime->format('Y-m-d\TH:i:s\Z'));
 
 $opencart_version = defined('VERSION') ? " OpenCart/".VERSION : "";


### PR DESCRIPTION
**1. Objective reason**

Solve a problem when setup a transfer with the amount greater than lower limit (฿30.00).

When setup a transfer with the amount greater than lower limit (฿30.00), the transfer was not setup and an error message, Omise Transfer amount must be greater than ฿30.00, appears in the red box at the top of screen.

This problem occurs only Thai Baht currency.

Related ticket: T424

**2. Description of change**

Format the transfer amount only Thai Baht into the #appropriate format.

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

High

**6. Alternate solution**

`-`