### PR TITLE
Add supported for SSL configuration when create link through Url class

### DIFF
--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -30,11 +30,11 @@ class ControllerPaymentOmise extends Controller {
 			if ($charge && $charge['authorized'] && $charge['captured']) {
 				// Status: processed.
 				$this->model_checkout_order->addOrderHistory($order_id, 15);
-				$this->response->redirect($this->url->link('checkout/success'));
+				$this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
 			} else {
 				// Status: failed.
 				$this->model_checkout_order->addOrderHistory($order_id, 10);
-				$this->response->redirect($this->url->link('checkout/failure'));
+				$this->response->redirect($this->url->link('checkout/failure', '', 'SSL'));
 			}
 		}
 
@@ -74,7 +74,7 @@ class ControllerPaymentOmise extends Controller {
 							"amount"      => OmisePluginHelperCharge::amount($order_info['currency_code'], $order_total),
 							"currency"    => $this->currency->getCode(),
 							"description" => $this->request->post['description'],
-							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
+							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
 							"card"        => $this->request->post['omise_token'],
 							"capture"     => $this->config->get('omise_auto_capture')
 						),
@@ -178,12 +178,12 @@ class ControllerPaymentOmise extends Controller {
 		if ($order_info) {
 			$data = array_merge($data, array(
 				'button_confirm'   => $this->language->get('button_confirm'),
-				'checkout_url'     => $this->url->link('payment/omise/checkout'),
-				'success_url'      => $this->url->link('checkout/success'),
+				'checkout_url'     => $this->url->link('payment/omise/checkout', '', 'SSL'),
+				'success_url'      => $this->url->link('checkout/success', '', 'SSL'),
 				'text_config_one'  => trim($this->config->get('text_config_one')),
 				'text_config_two'  => trim($this->config->get('text_config_two')),
 				'orderid'          => date('His') . $this->session->data['order_id'],
-				'callbackurl'      => $this->url->link('payment/custom/callback'),
+				'callbackurl'      => $this->url->link('payment/custom/callback', '', 'SSL'),
 				'orderdate'        => date('YmdHis'),
 				'currency'         => $order_info['currency_code'],
 				'orderamount'      => $this->currency->format($order_info['total'], $order_info['currency_code'] , false, false),


### PR DESCRIPTION
**1. Objective reason**

To support OpenCart SSL configuration.
If we look at the core code:
```php
// ./system/library/url.php

class Url {
    public function __construct($domain, $ssl = '') {
        $this->domain = $domain;
        $this->ssl = $ssl;
    }

    public function link($route, $args = '', $secure = false) {
        if (!$secure) {
            $url = $this->domain;
        } else {
            $url = $this->ssl;
        }
    }
}
```

```php
// ./index.php ; line: 58-65

if (!$store_query->num_rows) {
    $config->set('config_url', HTTP_SERVER);
    $config->set('config_ssl', HTTPS_SERVER);
}

// Url
$url = new Url($config->get('config_url'), $config->get('config_secure') ? $config->get('config_ssl') : $config->get('config_url'));
$registry->set('url', $url);
```

so, we could just add a param at the 3rd arg of that `Url::link()` method to tell OpenCart that we will use "SSL" config if it's possible (`config_secure` = `true`).

i.e.
`$this->url->link('some/url', '', 'SSL'));`

**2. Description of change**

- update `src/catalog/controller/payment/omise.php` to support `SSL` config

**3. Users affected by the change**

None

**4. Impact of the change**

None, it still support for `http` as normal.

**5. Priority of change**

Normal.

**6. Alternate solution (if any)**

No.
