### PR TITLE
Support IDR and SGD currencies.

### DIFF
--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -125,17 +125,11 @@ class ControllerPaymentOmise extends Controller {
 
                 // Check currency supports
                 if (! OmisePluginHelperCurrency::isSupport($this->config->get('config_currency'))) {
-                    // THB currency
-                    $thb_currency = $this->model_localisation_currency->getCurrencyByCode('THB');
-                    if (strtoupper($omise_balance['currency']) === "THB" && empty($thb_currency))
-                        $data['omise_dashboard']['warning'][] = sprintf($this->language->get('error_currency_thb_not_found'), $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL'));
-
-                    // JPY currency
-                    $jpy_currency = $this->model_localisation_currency->getCurrencyByCode('JPY');
-                    if (strtoupper($omise_balance['currency']) === "JPY" && empty($jpy_currency))
-                        $data['omise_dashboard']['warning'][] = sprintf($this->language->get('error_currency_jpy_not_found'), $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL'));
-
-                    $data['omise_dashboard']['warning'][] = sprintf($this->language->get('error_currency_not_support'), $this->config->get('config_currency'), $this->url->link('setting/store', 'token=' . $this->session->data['token'], 'SSL'));
+                    $data['omise_dashboard']['warning'][] = sprintf(
+                        $this->language->get('error_currency_not_support'),
+                        $this->config->get('config_currency'),
+                        $this->url->link('setting/store', 'token=' . $this->session->data['token'], 'SSL')
+                    );
                 }
             } catch (Exception $e) {
                 $data['omise_dashboard']['error'][] = $this->searchErrorTranslation($e->getMessage());

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -75,9 +75,7 @@ $_['button_create_transfer']                                   = 'Create transfe
 
 // Errors
 $_['error_extension_disabled']                                 = 'Please enable Omise Payment Gateway extension (check \'Setting\' tab).';
-$_['error_currency_thb_not_found']                             = 'Thai Baht (THB) currency was not found from your system. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/localisation/currency">learn more</a>';
-$_['error_currency_jpy_not_found']                             = 'Japanese Yen (JPY) currency was not found from your system. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/localisation/currency">learn more</a>';
-$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB) and Japanese Yen (JPY). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
+$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB), Indo Rupee (IDR), Japanese Yen (JPY) and Singapore Dollar (SGD). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
 $_['error_transfer_amount_is_empty']                           = 'Please submit your transfer amount.';
 $_['error_allowed_only_post_method']                           = 'Your method is not allowed';
 

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -75,7 +75,7 @@ $_['button_create_transfer']                                   = 'Create transfe
 
 // Errors
 $_['error_extension_disabled']                                 = 'Please enable Omise Payment Gateway extension (check \'Setting\' tab).';
-$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB), Indo Rupee (IDR), Japanese Yen (JPY) and Singapore Dollar (SGD). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
+$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB), Indonesian Rupiah (IDR), Japanese Yen (JPY) and Singapore Dollar (SGD). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
 $_['error_transfer_amount_is_empty']                           = 'Please submit your transfer amount.';
 $_['error_allowed_only_post_method']                           = 'Your method is not allowed';
 

--- a/src/admin/language/japanese/payment/omise.php
+++ b/src/admin/language/japanese/payment/omise.php
@@ -75,7 +75,7 @@ $_['button_create_transfer']                                   = '振込の要�
 
 // Errors
 $_['error_extension_disabled']                                 = 'Omiseペイメントゲートウェイの extension を有効化してください（\'設定\' タブを確認してください)';
-$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB), Indo Rupee (IDR), Japanese Yen (JPY) and Singapore Dollar (SGD). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
+$_['error_currency_not_support']                               = '現在、対応可能な通貨はタイバーツ(THB)、インドネシアルピア(IDR)、日本円(JPY)とシンガポールドル(SGD)のみとなっております。あなたのデフォルト通貨は<strong>%s</strong>に設定されています。<a href="%s">セットアップ</a> もしくは <a href="http://docs.opencart.com/system/setting/local">詳しく知る</a>';
 $_['error_transfer_amount_is_empty']                           = '振込希望金額を入力、送信してください。';
 $_['error_allowed_only_post_method']                           = '振込金額に問題があります。';
 

--- a/src/admin/language/japanese/payment/omise.php
+++ b/src/admin/language/japanese/payment/omise.php
@@ -75,9 +75,7 @@ $_['button_create_transfer']                                   = '振込の要�
 
 // Errors
 $_['error_extension_disabled']                                 = 'Omiseペイメントゲートウェイの extension を有効化してください（\'設定\' タブを確認してください)';
-$_['error_currency_thb_not_found']                             = 'タイバーツ(THB) は利用可能な設定となっていません。<a href="%s">セットアップ</a> もしくは <a href="http://docs.opencart.com/system/localisation/currency">詳しく知る</a>';
-$_['error_currency_jpy_not_found']                             = '日本円(JPY) は利用可能な設定となっていません。<a href="%s">セットアップ</a> もしくは <a href="http://docs.opencart.com/system/localisation/currency">詳しく知る</a>';
-$_['error_currency_not_support']                               = '現在、対応可能な通貨はタイバーツ(THB)と日本円(JPY)のみとなっております。あなたのデフォルト通貨は<strong>%s</strong>に設定されています。<a href="%s">セットアップ</a> もしくは <a href="http://docs.opencart.com/system/setting/local">詳しく知る</a>';
+$_['error_currency_not_support']                               = 'Currently, we only support Thai Baht (THB), Indo Rupee (IDR), Japanese Yen (JPY) and Singapore Dollar (SGD). Your default currency is <strong>%s</strong>. Please <a href="%s">setup</a> or <a href="http://docs.opencart.com/system/setting/local">learn more</a>';
 $_['error_transfer_amount_is_empty']                           = '振込希望金額を入力、送信してください。';
 $_['error_allowed_only_post_method']                           = '振込金額に問題があります。';
 

--- a/src/system/library/omise-plugin/helpers/charge.php
+++ b/src/system/library/omise-plugin/helpers/charge.php
@@ -3,22 +3,22 @@ if (! class_exists('OmisePluginHelperCharge')) {
     class OmisePluginHelperCharge
     {
         /**
-         * @param string  $currency
-         * @param integer $amount
+         * Format a Magento's amount to be a small-unit that Omise's API requires.
+         * Note, no specific format for JPY currency.
+         *
+         * @param  string  $currency
+         * @param  integer $amount
+         *
          * @return string
          */
         public static function amount($currency, $amount)
         {
             switch (strtoupper($currency)) {
                 case 'THB':
-                    // Convert to satang unit
+                case 'IDR':
+                case 'SGD':
+                    // Convert to a small unit
                     $amount = $amount * 100;
-                    break;
-
-                case 'JPY':
-                    break;
-
-                default:
                     break;
             }
 

--- a/src/system/library/omise-plugin/helpers/charge.php
+++ b/src/system/library/omise-plugin/helpers/charge.php
@@ -3,7 +3,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
     class OmisePluginHelperCharge
     {
         /**
-         * Format a Magento's amount to be a small-unit that Omise's API requires.
+         * Format an order's amount to be a small-unit that Omise's API accept.
          * Note, no specific format for JPY currency.
          *
          * @param  string  $currency

--- a/src/system/library/omise-plugin/helpers/currency.php
+++ b/src/system/library/omise-plugin/helpers/currency.php
@@ -10,7 +10,9 @@ if (! class_exists('OmisePluginHelperCurrency')) {
         {
             switch (strtoupper($currency_code)) {
                 case 'THB':
+                case 'IDR':
                 case 'JPY':
+                case 'SGD':
                     return true;
                     break;
             }
@@ -31,14 +33,24 @@ if (! class_exists('OmisePluginHelperCurrency')) {
                     if (preg_match('/\.00$/', $amount)) {
                         $amount = substr($amount, 0, -3);
                     }
+                    break;
 
+                case 'IDR':
+                    $amount = "Rp" . number_format(($amount / 100), 2);
+                    if (preg_match('/\.00$/', $amount)) {
+                        $amount = substr($amount, 0, -3);
+                    }
                     break;
 
                 case 'JPY':
-                    $amount = "¥" . number_format($amount);
+                    $amount = number_format($amount) . "円";
                     break;
 
-                default:
+                case 'SGD':
+                    $amount = "S$" . number_format(($amount / 100), 2);
+                    if (preg_match('/\.00$/', $amount)) {
+                        $amount = substr($amount, 0, -3);
+                    }
                     break;
             }
 

--- a/src/system/library/omise-plugin/helpers/transfer.php
+++ b/src/system/library/omise-plugin/helpers/transfer.php
@@ -3,22 +3,19 @@ if (! class_exists('OmisePluginHelperTransfer')) {
 	class OmisePluginHelperTransfer {
 		/**
 		 * Format the transfer amount into the appropriate format for each currency.
-		 * Now, only Thai Baht (THB) that need to format.
+         * Note, no specific format for JPY currency.
 		 *
-		 * Example for THB:
-		 * 100    => 10000
-		 * 100.00 => 10000
-		 * 100.25 => 10025
-		 * 100.50 => 10050
-		 * 100.1  => 10010
+		 * @param  string  $currency
+		 * @param  integer $amount
 		 *
-		 * @param string  $currency
-		 * @param integer $amount
 		 * @return string
 		 */
 		public static function amount($currency, $amount) {
 			switch (strtoupper($currency)) {
 				case 'THB':
+                case 'IDR':
+                case 'SGD':
+                    // Convert to a small unit
 					$amount = $amount * 100;
 					break;
 			}

--- a/src/system/library/omise-plugin/helpers/transfer.php
+++ b/src/system/library/omise-plugin/helpers/transfer.php
@@ -3,7 +3,7 @@ if (! class_exists('OmisePluginHelperTransfer')) {
 	class OmisePluginHelperTransfer {
 		/**
 		 * Format the transfer amount into the appropriate format for each currency.
-         * Note, no specific format for JPY currency.
+		 * Note, no specific format for JPY currency.
 		 *
 		 * @param  string  $currency
 		 * @param  integer $amount
@@ -13,9 +13,9 @@ if (! class_exists('OmisePluginHelperTransfer')) {
 		public static function amount($currency, $amount) {
 			switch (strtoupper($currency)) {
 				case 'THB':
-                case 'IDR':
-                case 'SGD':
-                    // Convert to a small unit
+				case 'IDR':
+				case 'SGD':
+					// Convert to a small unit
 					$amount = $amount * 100;
 					break;
 			}


### PR DESCRIPTION
#### 1. Objective

To make plugin support the following currencies.
- IDR (Indonesian Rupiah)
- SGD (Singapore Dollar)

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2244, T2245

#### 2. Description of change

- Be able to create charge with new supported currencies "IDR" and "SGD" currencies.

- Format the display of transaction amount at the plugin dashboard page.

- Modify a warning message that informed about unsupported currency at administrator side.

Note:
The currency THB and JPY have been already supported.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 2.0.3.1.
- **Omise plugin version**: Omise-OpenCart 2.0.0.1
- **PHP versions**: 5.6.28 and 7.0.15

**✏️ Details:**

1. ✅ Test checkout with "IDR" currency
    1.1. At admin page, locate to `System > Settings`. Then, edit your store.
    1.2. At the store editing page, choose `Local` tab and update currency to `IDR`
    1.3. Do normal checkout process.
    1.4. Check a result from Omise log, at request parameters, `currency` must be `IDR` and amount must be subunit (i.e. set product price to `15,025`, the amount that send to Omise must be `1502500`).

    <img width="836" alt="screen shot 2560-02-17 at 1 50 19 am" src="https://cloud.githubusercontent.com/assets/2154669/23035936/846a9676-f4b3-11e6-9ba4-3976e14dc2dd.png">

    ![screen shot 2560-02-17 at 1 52 32 am](https://cloud.githubusercontent.com/assets/2154669/23035997/cbc2af2c-f4b3-11e6-836a-d4b280916982.png)

2. ✅ Test checkout with "SGD" currency
    2.1. At admin page, locate to `System > Settings`. Then, edit your store.
    2.2. At the store editing page, choose `Local` tab and update currency to `SGD`
    2.3. Do normal checkout process.
    2.4. Check a result from Omise log, at request parameters, `currency` must be `SGD` and amount must be subunit (i.e. set product price to `15,025`, the amount that send to Omise must be `1502500`).
    > _note, SGD currency is currently not supported, this test was made with Omise Japan account. But basically, just test that those parameters were passed to Omise API correctly._

    <img width="664" alt="screen shot 2560-02-17 at 2 04 59 am" src="https://cloud.githubusercontent.com/assets/2154669/23036494/a166218a-f4b5-11e6-967b-aa587bc4ddaf.png">

3. ✅ Test if use currency that doesn't match with the merchant account's currency, it must raise an error. (i.e. this test set store currency to `USD` but use keys from `Omise Indo account`)
    > _note, error message came from Omise API_
    <img width="1241" alt="screen shot 2560-02-17 at 1 46 49 am" src="https://cloud.githubusercontent.com/assets/2154669/23036059/ece113b0-f4b3-11e6-9220-65a9381d8220.png">

4. ✅ At the plugin dashboard page, JPY currency should display an amount as `30,133円` instead of `¥30,133`.
    ![screen shot 2560-02-17 at 2 00 22 am](https://cloud.githubusercontent.com/assets/2154669/23036302/e547c922-f4b4-11e6-8777-4a92525bdca1.png)

5. ✅ At the plugin dashboard page, IDR currency should display an amount as `Rp54,000`.
    ![screen shot 2560-02-17 at 1 15 50 am](https://cloud.githubusercontent.com/assets/2154669/23034508/a4cce4b4-f4ae-11e6-970c-5258f251c436.png)

    ![screen shot 2560-02-17 at 1 31 05 am](https://cloud.githubusercontent.com/assets/2154669/23035158/cb01578a-f4b0-11e6-97fc-e1b46378df5e.png)

6. ✅ Test create transfer with IDR currency
    6.1. This test was made with amount `6002.45` and `6001` (second row)
    ![screen shot 2560-02-17 at 1 40 40 am](https://cloud.githubusercontent.com/assets/2154669/23035592/322eb956-f4b2-11e6-912d-92e66180c8a4.png)

7. ✅ At the plugin dashboard page, SGD currency should display an amount as `S$54,000`.

    > _note, this test I used Omise Indo account to test, but bypass currency (hard-code to `SGD` instead of use variable) at `OmisePluginHelperCurrency::format()` to see the result._

    ![screen shot 2560-02-17 at 1 56 28 am](https://cloud.githubusercontent.com/assets/2154669/23036216/8b520504-f4b4-11e6-84f7-7eec176c7204.png)


#### 4. Impact of the change

Nothing.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

- SGD currency is currently not supported from Omise API. This pull request just for prepare the plugin to be ready for coming feature.

- The screenshot below shows the tested success checkouts for currencies, IDR, JPY and THB and fail checkout for unsupported currency USD on OpenCart 2.0.3.1.

![screenshot-54 254 157 179-2017-03-22-18-40-39](https://cloud.githubusercontent.com/assets/4145121/24196268/b81902d2-0f2f-11e7-9858-ab14b1af5d6c.png)

1. The first row (Order ID 8) is a success order for JPY.
2. The second row (Order ID 7) is a success order for IDR.
3. The third row (Order ID 6) is a success order for THB.
4. The fourth row (Order ID 4) is a fail order for unsupported currency USD.