### PR TITLE
Support JPY, IDR and SGD currencies.

### DIFF
--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -415,6 +415,8 @@ class ControllerPaymentOmise extends Controller
          * Prepare and loading necessary scripts.
          *
          */
+        $this->load->helper('omise_currency');
+
         // Load model.
         $this->load->model('payment/omise');
 
@@ -429,7 +431,9 @@ class ControllerPaymentOmise extends Controller
             if (!isset($this->request->post['OmiseTransfer']['amount']))
                 throw new Exception($this->language->get('error_need_amount_value'), 1);
 
-            $transferring = $this->model_payment_omise->createOmiseTransfer($this->request->post['OmiseTransfer']['amount']);
+            // Retrieve Omise Balance.
+            $balance      = $this->model_payment_omise->getOmiseBalance();
+            $transferring = $this->model_payment_omise->createOmiseTransfer(formatChargeAmount($balance['currency'], $this->request->post['OmiseTransfer']['amount']));
             if (isset($transferring['error']))
                 throw new Exception('Omise Transfer:: '.$transferring['error'], 1);
             else

--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -18,6 +18,8 @@ class ControllerPaymentOmise extends Controller
          * Prepare and loading necessary scripts.
          *
          */
+        $this->load->helper('omise_currency');
+
         // Load model.
         $this->load->model('payment/omise');
 

--- a/src/admin/view/template/payment/omise_dashboard.tpl
+++ b/src/admin/view/template/payment/omise_dashboard.tpl
@@ -54,8 +54,8 @@ echo $header; ?>
 
                 <!-- Balance -->
                 <div class="omise-balance omise-clearfix">
-                    <div class="left"><span class="omise-number"><?php echo number_format(($omise['balance']['total']/100), 2); ?></span><br/>Total Balance</div>
-                    <div class="right"><span class="omise-number"><?php echo number_format(($omise['balance']['available']/100), 2); ?></span><br/>Transferable Balance</div>
+                    <div class="left"><span class="omise-number"><?php echo formatDisplayPrice($omise['balance']['currency'], $omise['balance']['total']); ?></span><br/>Total Balance</div>
+                    <div class="right"><span class="omise-number"><?php echo formatDisplayPrice($omise['balance']['currency'], $omise['balance']['available']); ?></span><br/>Transferable Balance</div>
                 </div>
 
                 <!-- Transfer History -->
@@ -75,7 +75,7 @@ echo $header; ?>
                         <tbody>
                             <?php foreach ($omise['transfer']['data'] as $key => $value): $date = new \DateTime($value['created']); ?>
                                 <tr>
-                                    <td class="left"><?php echo number_format(($value['amount']/100), 2); ?></td>
+                                    <td class="left"><?php echo formatDisplayPrice($omise['balance']['currency'], $value['amount']); ?></td>
                                     <td class="left"><?php echo $value['id']; ?></td>
                                     <td class="left"><?php echo $value['sent'] ? 'Yes' : 'No'; ?></td>
                                     <td class="left"><?php echo $value['paid'] ? 'Yes' : 'No'; ?></td>

--- a/src/system/helper/omise_currency.php
+++ b/src/system/helper/omise_currency.php
@@ -1,0 +1,89 @@
+<?php
+if (! function_exists('isSupport')) {
+    /**
+     * @param  string $currency
+     *
+     * @return boolean
+     */
+    function isSupport($currency)
+    {
+        switch (strtoupper($currency)) {
+            case 'THB':
+            case 'IDR':
+            case 'JPY':
+            case 'SGD':
+                return true;
+                break;
+        }
+
+        return false;
+    }
+}
+
+if (! function_exists('formatDisplayPrice')) {
+    /**
+     * Format an amount to display along with the currency's sign correctly.
+     *
+     * @param  string          $currency
+     * @param  integer | float $amount
+     *
+     * @return integer
+     */
+    function formatDisplayPrice($currency, $amount)
+    {
+        switch (strtoupper($currency)) {
+            case 'THB':
+                $amount = "฿" . number_format(($amount / 100), 2);
+                if (preg_match('/\.00$/', $amount)) {
+                    $amount = substr($amount, 0, -3);
+                }
+                break;
+
+            case 'IDR':
+                $amount = "Rp" . number_format(($amount / 100), 2);
+                if (preg_match('/\.00$/', $amount)) {
+                    $amount = substr($amount, 0, -3);
+                }
+                break;
+
+            case 'SGD':
+                $amount = "S$" . number_format(($amount / 100), 2);
+                if (preg_match('/\.00$/', $amount)) {
+                    $amount = substr($amount, 0, -3);
+                }
+                break;
+
+            case 'JPY':
+                $amount = number_format($amount) . "円";
+                break;
+        }
+
+        return $amount;
+    }
+}
+
+
+if (! function_exists('formatChargeAmount')) {
+    /**
+     * Format an order amount to be a small-unit that Omise's API accept.
+     * Note, no specific format for JPY currency.
+     *
+     * @param  string          $currency
+     * @param  integer | float $amount
+     *
+     * @return integer
+     */
+    function formatChargeAmount($currency, $amount)
+    {
+        switch (strtoupper($currency)) {
+            case 'THB':
+            case 'IDR':
+            case 'SGD':
+                // Convert to a small unit
+                $amount = $amount * 100;
+                break;
+        }
+
+        return $amount;
+    }
+}


### PR DESCRIPTION
#### 1. Objective

To make plugin support the following currencies.
- JPY (Japanese yen)
- IDR (Indonesian rupiah)
- SGD (Singapore dollar)

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2244, T2245

#### 2. Description of change

- Be able to create charge with "THB", "JPY", "IDR", "SGD" currencies.

- Format the display of transaction amount at the plugin dashboard page.

- Format the amount before send it to Omise API for create an Omise transfer.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 1.5.6.4.
- **Omise plugin version**: Omise-OpenCart 1.5.0.2
- **PHP version**: 5.6.28

**✏️ Details:**

1. ✅ Test checkout with "JPY" currency
    1.1. At admin page, locate to `System > Settings`. Then, edit your store.
    1.2. At the store editing page, choose `Local` tab and update currency to `JPY`
    1.3. Do normal checkout process.
    1.4. Check a result from Omise log, at request parameters, `currency` must be `JPY` and amount must be the same as in an order total (i.e. product price is `15,025`, the amount that send to Omise must be `15025`).

2. ✅ Test checkout with "IDR" currency
    2.1. At admin page, locate to `System > Settings`. Then, edit your store.
    2.2. At the store editing page, choose `Local` tab and update currency to `IDR`
    2.3. Do normal checkout process.
    2.4. Check a result from Omise log, at request parameters, `currency` must be `IDR` and amount must be subunit (i.e. set product price to `15,025`, the amount that send to Omise must be `1502500`).

3. ✅ Test checkout with "SGD" currency
    3.1. At admin page, locate to `System > Settings`. Then, edit your store.
    3.2. At the store editing page, choose `Local` tab and update currency to `SGD`
    3.3. Do normal checkout process.
    3.4. Check a result from Omise log, at request parameters, `currency` must be `SGD` and amount must be subunit (i.e. set product price to `15,025`, the amount that send to Omise must be `1502500`).
    > _note, SGD currency is currently not supported, this test was made with Omise Japan account. But basically, just test that those parameters were passed to Omise API correctly._

4. ✅ Test if use currency that doesn't match with the merchant account's currency, it must raise an error. (i.e. this test set store currency to `USD` but use keys from `Omise Indonesian account`)
    > _note, error message came from Omise API_

5. ✅ At the plugin dashboard page, JPY currency should display an amount as `30,133円` instead of `¥30,133`.

6. ✅ At the plugin dashboard page, IDR currency should display an amount as `Rp54,000`.

7. ✅ Test create transfer with IDR currency
    7.1. This test was made with amount `6002.45` and `6001` (second row)

8. ✅ At the plugin dashboard page, SGD currency should display an amount as `S$54,000`.
    > _note, this test I used Omise Indonesian account to test, but bypass currency (hard-code to `SGD` instead of use variable) at `OmisePluginHelperCurrency::format()` to see the result._

#### 4. Impact of the change

Nothing.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

- SGD currency is currently not supported from Omise API. This pull request just for prepare the plugin to be ready for coming feature.

- The screenshot below shows the tested success checkouts for currencies, IDR, JPY and THB on OpenCart 1.5.6.4.

![success_orders_for_each_currencies_on_opencart_1 5 6 4](https://cloud.githubusercontent.com/assets/4145121/24143451/55de8f34-0e5c-11e7-9fff-8bb8c07c755b.png)

1. The first row (Order ID 9) is an order for THB.
2. The second row (Order ID 7) is an order for JPY.
3. The third row (Order ID 4) is an order for IDR.

- The screenshot below shows the incorrect checkout, create Omise charge with USD but the Omise account is Thai account.

![invalid_checkout_unsupported_currency_on_opencart_1 5 6 4](https://cloud.githubusercontent.com/assets/4145121/24144164/df5183dc-0e5e-11e7-9d3d-2c7a3a7fee27.png)
