### PR TITLE
Add Internet Banking config at the payment setting page

### DIFF
--- a/src/admin/controller/payment/omise_offsite.php
+++ b/src/admin/controller/payment/omise_offsite.php
@@ -1,0 +1,218 @@
+<?php
+class ControllerPaymentOmiseOffsite extends Controller {
+    /**
+     * @var array
+     */
+    private $error = array();
+
+    /**
+     * @return string
+     */
+    private function flashSuccessMessages() {
+        if (isset($this->session->data['success'])) {
+            $msg = $this->session->data['success'];
+            unset($this->session->data['success']);
+
+            return $msg;
+        }
+
+        return "";
+    }
+
+    /**
+     * @return string
+     */
+    private function flashErrorMessages() {
+        if (isset($this->session->data['error'])) {
+            $msg = $this->session->data['error'];
+            unset($this->session->data['error']);
+
+            return $msg;
+        }
+
+        return "";
+    }
+
+    /**
+     * Set page breadcrumb
+     * @return array
+     */
+    private function setBreadcrumb($current = null) {
+        $this->load->language('payment/omise_offsite');
+
+        // Set Breadcrumbs.
+        $breadcrumbs = array();
+
+        $breadcrumbs[] = array(
+            'text'      => $this->language->get('text_home'),
+            'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => false
+        );
+
+        $breadcrumbs[] = array(
+            'text'      => $this->language->get('text_payment'),
+            'href'      => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => ' :: '
+        );
+
+        $breadcrumbs[] = array(
+            'text'      => $this->language->get('heading_title'),
+            'href'      => $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => ' :: '
+        );
+
+        if (! is_null($current))
+            $breadcrumbs[] = $current;
+
+        return $breadcrumbs;
+    }
+ 
+    /**
+     * @return array
+     */
+    private function pageDataSettingTab() {
+        return array(
+            'omise_offsite_status'        => $this->config->get('omise_offsite_status'),
+            'omise_offsite_payment_title' => $this->config->get('omise_offsite_payment_title')
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function pageTranslation() {
+        $this->load->language('payment/omise_offsite');
+
+        return array(
+            'heading_title'                     => $this->language->get('heading_title'),
+            'label_setting_module_config'       => $this->language->get('label_setting_module_config'),
+            'label_setting_module_status'       => $this->language->get('label_setting_module_status'),
+            'label_omise_offsite_payment_title' => $this->language->get('label_omise_offsite_payment_title'),
+            'text_enabled'                      => $this->language->get('text_enabled'),
+            'text_disabled'                     => $this->language->get('text_disabled'),
+            'button_save'                       => $this->language->get('button_save'),
+            'button_cancel'                     => $this->language->get('button_cancel'),
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function searchErrorTranslation($clue) {
+        $this->load->language('payment/omise_offsite');
+
+        $translate_code = 'error_' . str_replace(' ', '_', strtolower($clue));
+        $translate_msg  = $this->language->get($translate_code);
+
+        if ($translate_code !== $translate_msg)
+            return $translate_msg;
+
+        return $clue;
+    }
+
+    /**
+     * @return void
+     */
+    private function redirectTo($destination) {
+        switch ($destination) {
+            case 'omise_dashboard':
+                $this->response->redirect($this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'));
+                break;
+
+            default:
+                $this->response->redirect($this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'));
+                break;
+        }
+    }
+
+    /**
+     * This method will fire when user click `install` button from `extension/payment` page
+     * It will call `model/payment/omise_offsite.php` file and run `install` method for installl stuff
+     * that necessary to use in Omise Payment Gateway Internet Banking module
+     * @return void
+     */
+    public function install() {
+        $this->load->model('payment/omise_offsite');
+
+        try {
+            // Install the extension
+            if (! $this->model_payment_omise_offsite->install())
+                throw new Exception('', 1);
+        } catch (Exception $e) {
+            // Uninstall
+            $this->load->controller('extension/payment/uninstall');
+        }
+    }
+
+    /**
+     * This method will fire when user click `Uninstall` button from `extension/payment` page
+     * Uninstall everything that related with Omise Payment Gateway module.
+     * @return void
+     */
+    public function uninstall() {
+
+    }
+
+    /**
+     * (GET) Page, route=payment/omise_offsite
+     */
+    public function index() {
+        // POST Request handle
+        if (($this->request->server['REQUEST_METHOD'] == 'POST'))
+            $this->updateConfig();
+
+        $this->load->language('payment/omise_offsite');
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        // Manipulate page's data
+        $data = array_merge(
+            $this->pageDataSettingTab(),
+            $this->pageTranslation(),
+            array(
+                'success'            => $this->flashSuccessMessages(),
+                'error_warning'      => $this->flashErrorMessages(),
+                'action'             => $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'),
+                'cancel'             => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
+            )
+        );
+
+        // Page templates
+        $data = array_merge($data, array(
+            'header'      => $this->load->controller('common/header'),
+            'breadcrumbs' => $this->setBreadcrumb(null),
+            'column_left' => $this->load->controller('common/column_left'),
+            'footer'      => $this->load->controller('common/footer')
+        ));
+
+        $this->response->setOutput($this->load->view('payment/omise_offsite.tpl', $data));
+    }
+
+    /**
+     * (POST)
+     * @return void
+     */
+    public function updateConfig() {
+        $this->load->model('setting/setting');
+        $this->load->language('payment/omise_offsite');
+
+        try {
+            // Allowed only POST method
+            if ($this->request->server['REQUEST_METHOD'] !== 'POST')
+                throw new Exception($this->language->get('error_allowed_only_post_method'), 1);
+
+            $update = $this->request->post;
+            if (! empty($update)) {
+                if ($update['omise_offsite_status'] == 1 && $this->config->get('omise_status') != 1) {
+                    throw new Exception($this->language->get('error_need_omise_extension'));
+                }
+                // Update
+                $this->model_setting_setting->editSetting('omise_offsite', $update);
+                $this->session->data['success'] = $this->language->get('text_session_save');
+            }
+        } catch (Exception $e) {
+            $this->session->data['error'] = $this->searchErrorTranslation($e->getMessage());
+        }
+
+        $this->redirectTo('omise_offsite_setting');
+    }
+}

--- a/src/admin/controller/payment/omise_offsite.php
+++ b/src/admin/controller/payment/omise_offsite.php
@@ -1,5 +1,6 @@
 <?php
-class ControllerPaymentOmiseOffsite extends Controller {
+class ControllerPaymentOmiseOffsite extends Controller
+{
     /**
      * @var array
      */
@@ -8,7 +9,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return string
      */
-    private function flashSuccessMessages() {
+    private function flashSuccessMessages()
+    {
         if (isset($this->session->data['success'])) {
             $msg = $this->session->data['success'];
             unset($this->session->data['success']);
@@ -22,7 +24,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return string
      */
-    private function flashErrorMessages() {
+    private function flashErrorMessages()
+    {
         if (isset($this->session->data['error'])) {
             $msg = $this->session->data['error'];
             unset($this->session->data['error']);
@@ -37,7 +40,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
      * Set page breadcrumb
      * @return array
      */
-    private function setBreadcrumb($current = null) {
+    private function setBreadcrumb($current = null)
+    {
         $this->load->language('payment/omise_offsite');
 
         // Set Breadcrumbs.
@@ -61,8 +65,9 @@ class ControllerPaymentOmiseOffsite extends Controller {
             'separator' => ' :: '
         );
 
-        if (! is_null($current))
+        if (! is_null($current)) {
             $breadcrumbs[] = $current;
+        }
 
         return $breadcrumbs;
     }
@@ -70,7 +75,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return array
      */
-    private function pageDataSettingTab() {
+    private function pageDataSettingTab()
+    {
         return array(
             'omise_offsite_status'        => $this->config->get('omise_offsite_status'),
             'omise_offsite_payment_title' => $this->config->get('omise_offsite_payment_title')
@@ -80,7 +86,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return array
      */
-    private function pageTranslation() {
+    private function pageTranslation()
+    {
         $this->load->language('payment/omise_offsite');
 
         return array(
@@ -98,14 +105,16 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return string
      */
-    private function searchErrorTranslation($clue) {
+    private function searchErrorTranslation($clue)
+    {
         $this->load->language('payment/omise_offsite');
 
         $translate_code = 'error_' . str_replace(' ', '_', strtolower($clue));
         $translate_msg  = $this->language->get($translate_code);
 
-        if ($translate_code !== $translate_msg)
+        if ($translate_code !== $translate_msg) {
             return $translate_msg;
+        }
 
         return $clue;
     }
@@ -113,7 +122,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * @return void
      */
-    private function redirectTo($destination) {
+    private function redirectTo($destination)
+    {
         switch ($destination) {
             case 'omise_dashboard':
                 $this->response->redirect($this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'));
@@ -131,13 +141,15 @@ class ControllerPaymentOmiseOffsite extends Controller {
      * that necessary to use in Omise Payment Gateway Internet Banking module
      * @return void
      */
-    public function install() {
+    public function install()
+    {
         $this->load->model('payment/omise_offsite');
 
         try {
             // Install the extension
-            if (! $this->model_payment_omise_offsite->install())
+            if (! $this->model_payment_omise_offsite->install()) {
                 throw new Exception('', 1);
+            }
         } catch (Exception $e) {
             // Uninstall
             $this->load->controller('extension/payment/uninstall');
@@ -149,17 +161,19 @@ class ControllerPaymentOmiseOffsite extends Controller {
      * Uninstall everything that related with Omise Payment Gateway module.
      * @return void
      */
-    public function uninstall() {
-
+    public function uninstall()
+    {
     }
 
     /**
      * (GET) Page, route=payment/omise_offsite
      */
-    public function index() {
+    public function index()
+    {
         // POST Request handle
-        if (($this->request->server['REQUEST_METHOD'] == 'POST'))
+        if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
             $this->updateConfig();
+        }
 
         $this->load->language('payment/omise_offsite');
         $this->document->setTitle($this->language->get('heading_title'));
@@ -191,14 +205,16 @@ class ControllerPaymentOmiseOffsite extends Controller {
      * (POST)
      * @return void
      */
-    public function updateConfig() {
+    public function updateConfig()
+    {
         $this->load->model('setting/setting');
         $this->load->language('payment/omise_offsite');
 
         try {
             // Allowed only POST method
-            if ($this->request->server['REQUEST_METHOD'] !== 'POST')
+            if ($this->request->server['REQUEST_METHOD'] !== 'POST') {
                 throw new Exception($this->language->get('error_allowed_only_post_method'), 1);
+            }
 
             $update = $this->request->post;
             if (! empty($update)) {

--- a/src/admin/language/english/payment/omise_offsite.php
+++ b/src/admin/language/english/payment/omise_offsite.php
@@ -1,0 +1,36 @@
+<?php
+// Module title
+$_['heading_title']                                            = 'Omise Payment Gateway - Internet Banking';
+$_['text_omise_offsite']                                       = '<a href="https://www.omise.co" target="_blank" style="border: 1px solid #EEEEEE; padding: 2px; width: 94px; max-height:25px; display: inline-block;" alt="Omise Payment Gateway"" title="Omise Payment Gateway"><img src="view/image/payment/omise-payment.png" alt="Omise Payment Gateway"" title="Omise Payment Gateway" style="max-height:18px;" /></a>';
+
+
+// Labels
+$_['label_setting_module_config']                              = 'Module Config';
+$_['label_setting_module_status']                              = 'Module Status';
+
+
+// Omise's labels
+$_['label_omise_offsite_payment_title']                        = 'Payment method title';
+
+
+// Breadcrumb menu.
+$_['text_home']                                                = 'Home';
+$_['text_payment']                                             = 'Payments';
+
+
+// Messages
+$_['text_enabled']                                             = 'Enabled';
+$_['text_disabled']                                            = 'Disabled';
+$_['text_session_save']                                        = 'Saved.';
+
+
+// Action buttons
+$_['button_save']                                              = 'Save';
+$_['button_cancel']                                            = 'Cancel';
+
+
+// Errors
+$_['error_need_omise_extension']                               = 'Please install and enable <strong>Omise Payment Gateway</strong> extension before enabling <strong>Omise Payment Gateway - Internet Banking</strong> (check \'Setting\' tab).';
+
+
+?>

--- a/src/admin/language/japanese/payment/omise_offsite.php
+++ b/src/admin/language/japanese/payment/omise_offsite.php
@@ -30,7 +30,7 @@ $_['button_cancel']                                            = 'キャンセ�
 
 
 // Errors
-$_['error_need_omise_extension']                               = 'Please install and enable <strong>Omise Payment Gateway</strong> extension before enabling <strong>Omise Payment Gateway - Internet Banking</strong> (check \'Setting\' tab).';
+$_['error_need_omise_extension']                               = '<strong>Omise Payment Gateway - Internet Banking</strong>を有効化する前に、<strong>Omise Payment Gateway</strong>拡張をインストール・有効化してください(\'設定\'タブをご確認ください)。';
 
 
 ?>

--- a/src/admin/language/japanese/payment/omise_offsite.php
+++ b/src/admin/language/japanese/payment/omise_offsite.php
@@ -1,0 +1,36 @@
+< ?php
+// Module title
+$_['heading_title']                                            = 'Omise Payment Gateway - Internet Banking';
+$_['text_omise_offsite']                                       = '<a href="https://www.omise.co/ja" target="_blank" style="border: 1px solid #EEEEEE; padding: 2px; width: 94px; max-height:25px; display: inline-block;" alt="Omise Payment Gateway"" title="Omise Payment Gateway"><img src="view/image/payment/omise-payment.png" alt="Omise Payment Gateway"" title="Omise Payment Gateway" style="max-height:18px;" /></a>';
+
+
+// Labels
+$_['label_setting_module_config']                              = 'モジュール設定';
+$_['label_setting_module_status']                              = 'モジュール状況';
+
+
+// Omise's labels
+$_['label_omise_offsite_payment_title']                        = '決済方法';
+
+
+// Breadcrumb menu.
+$_['text_home']                                                = 'ホーム';
+$_['text_payment']                                             = '決済';
+
+
+// Messages
+$_['text_enabled']                                             = '有効化';
+$_['text_disabled']                                            = '無効化';
+$_['text_session_save']                                        = '保存されました';
+
+
+// Action buttons
+$_['button_save']                                              = '保存';
+$_['button_cancel']                                            = 'キャンセル';
+
+
+// Errors
+$_['error_need_omise_extension']                               = 'Please install and enable <strong>Omise Payment Gateway</strong> extension before enabling <strong>Omise Payment Gateway - Internet Banking</strong> (check \'Setting\' tab).';
+
+
+?>

--- a/src/admin/language/japanese/payment/omise_offsite.php
+++ b/src/admin/language/japanese/payment/omise_offsite.php
@@ -1,4 +1,4 @@
-< ?php
+<?php
 // Module title
 $_['heading_title']                                            = 'Omise Payment Gateway - Internet Banking';
 $_['text_omise_offsite']                                       = '<a href="https://www.omise.co/ja" target="_blank" style="border: 1px solid #EEEEEE; padding: 2px; width: 94px; max-height:25px; display: inline-block;" alt="Omise Payment Gateway"" title="Omise Payment Gateway"><img src="view/image/payment/omise-payment.png" alt="Omise Payment Gateway"" title="Omise Payment Gateway" style="max-height:18px;" /></a>';

--- a/src/admin/model/payment/omise_offsite.php
+++ b/src/admin/model/payment/omise_offsite.php
@@ -1,10 +1,12 @@
 <?php
-class ModelPaymentOmiseOffsite extends Model {
+class ModelPaymentOmiseOffsite extends Model
+{
     /**
      * Install a table that need to use in Omise Payment Gateway module
      * @return boolean
      */
-    public function install() {
+    public function install()
+    {
         $this->load->model('setting/setting');
         $this->model_setting_setting->editSetting($this->_group, array(
             'omise_offsite_status'        => 0,
@@ -18,7 +20,8 @@ class ModelPaymentOmiseOffsite extends Model {
      * Drop table when uninstall Omise Payment Gateway module
      * @return boolean
      */
-    public function uninstall() {
+    public function uninstall()
+    {
         // ...
     }
 
@@ -26,7 +29,8 @@ class ModelPaymentOmiseOffsite extends Model {
      * Get config from table
      * @return array|boolean
      */
-    public function getConfig() {
+    public function getConfig()
+    {
         try {
             $this->load->model('setting/setting');
             $this->model_setting_setting->getSetting($this->_group);

--- a/src/admin/model/payment/omise_offsite.php
+++ b/src/admin/model/payment/omise_offsite.php
@@ -1,0 +1,37 @@
+<?php
+class ModelPaymentOmiseOffsite extends Model {
+    /**
+     * Install a table that need to use in Omise Payment Gateway module
+     * @return boolean
+     */
+    public function install() {
+        $this->load->model('setting/setting');
+        $this->model_setting_setting->editSetting($this->_group, array(
+            'omise_offsite_status'        => 0,
+            'omise_offsite_payment_title' => 'Internet Banking (Powered by Omise)'
+        ));
+
+        return true;
+    }
+
+    /**
+     * Drop table when uninstall Omise Payment Gateway module
+     * @return boolean
+     */
+    public function uninstall() {
+        // ...
+    }
+
+    /**
+     * Get config from table
+     * @return array|boolean
+     */
+    public function getConfig() {
+        try {
+            $this->load->model('setting/setting');
+            $this->model_setting_setting->getSetting($this->_group);
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+}

--- a/src/admin/view/template/payment/omise.tpl
+++ b/src/admin/view/template/payment/omise.tpl
@@ -220,7 +220,7 @@ echo $header; ?><?php echo $column_left; ?>
             </div>
 
             <div class="panel-body">
-              <!-- Module config -->
+              <!-- Module status -->
               <div class="form-group required">
                 <label class="col-sm-2 control-label" for="omise_status"><?php echo $label_setting_module_status; ?></label>
                 <div class="col-sm-10">
@@ -229,16 +229,17 @@ echo $header; ?><?php echo $column_left; ?>
                     <option value="0" <?php echo !$omise_status ? 'selected="selected"' : ''; ?>><?php echo $text_disabled; ?></option>
                   </select>
                 </div>
-              </div> <!-- /END Module config (.form-group) -->
+              </div> <!-- /END Module status (.form-group) -->
 
-              <!-- Test public key -->
+              <!-- Payment method title -->
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="omise_payment_title"><?php echo $label_omise_payment_title; ?></label>
                 <div class="col-sm-10">
                   <input type="text" name="omise_payment_title" value="<?php echo $omise_payment_title; ?>" id="omise_payment_title" class="form-control" />
                 </div>
-              </div>
+              </div> <!-- /END Payment method title -->
 
+              <!-- Live mode -->
               <div class="form-group">
                 <label class="col-sm-2 control-label" for=""></label>
                 <div class="col-sm-10">
@@ -251,7 +252,7 @@ echo $header; ?><?php echo $column_left; ?>
                     <?php echo $label_omise_mode_live; ?>
                   </label>
                 </div>
-              </div> <!-- /END Module config (.form-group) -->
+              </div> <!-- /END Live mode (.form-group) -->
             </div> <!-- /END .panel-body -->
           </div> <!-- /END .panel.panel-default -->
 

--- a/src/admin/view/template/payment/omise_offsite.tpl
+++ b/src/admin/view/template/payment/omise_offsite.tpl
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Include header.
+ *
+ */
+echo $header; ?><?php echo $column_left; ?>
+
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="pull-right">
+        <button type="submit" onclick="$('#form-setting').submit();" data-toggle="tooltip" title="<?php echo $button_save; ?>" class="btn btn-primary"><i class="fa fa-save"></i></button>
+        <a href="<?php echo $cancel; ?>" data-toggle="tooltip" title="<?php echo $button_cancel; ?>" class="btn btn-default"><i class="fa fa-reply"></i></a>
+      </div>
+
+      <h1><?php echo $heading_title; ?></h1>
+      <ul class="breadcrumb">
+        <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+          <li><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a></li>
+        <?php } ?>
+      </ul>
+    </div>
+  </div> <!-- /END .page-header -->
+
+  <div class="container-fluid">
+    <?php if ($error_warning) { ?>
+      <div class="alert alert-danger">
+        <i class="fa fa-exclamation-circle"></i>
+        <?php if (is_array($error_warning)) {
+          foreach ($error_warning as $key => $value) { echo $value; }
+        } else {
+          echo $error_warning;
+        } ?>
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    <?php } ?>
+    <?php if ($success) { ?>
+      <div class="alert alert-success"><i class="fa fa-check-circle"></i> <?php echo $success; ?>
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    <?php } ?>
+
+    <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="form-setting" class="form-horizontal">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title"><i class="fa fa-pencil"></i> <?php echo $label_setting_module_config; ?></h3>
+        </div>
+
+        <div class="panel-body">
+          <!-- Module status -->
+          <div class="form-group required">
+            <label class="col-sm-2 control-label" for="omise_offsite_status"><?php echo $label_setting_module_status; ?></label>
+            <div class="col-sm-10">
+              <select name="omise_offsite_status" class="form-control">
+                <option value="1" <?php echo $omise_offsite_status ? 'selected="selected"' : ''; ?>><?php echo $text_enabled; ?></option>
+                <option value="0" <?php echo !$omise_offsite_status ? 'selected="selected"' : ''; ?>><?php echo $text_disabled; ?></option>
+              </select>
+            </div>
+          </div> <!-- /END Module status (.form-group) -->
+
+          <!-- Payment method title -->
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="omise_offsite_payment_title"><?php echo $label_omise_offsite_payment_title; ?></label>
+            <div class="col-sm-10">
+              <input type="text" name="omise_offsite_payment_title" value="<?php echo $omise_offsite_payment_title; ?>" id="omise_offsite_payment_title" class="form-control" />
+            </div>
+          </div> <!-- /END Payment method title -->
+        </div> <!-- /END .panel-body -->
+      </div> <!-- /END .panel.panel-default -->
+    </form>
+  </div> <!-- /END .container-fluid -->
+</div> <!-- /END #content -->
+
+<!-- Include Omise's stylesheet -->
+<link rel="stylesheet" type="text/css" href="view/stylesheet/omise.css">
+
+<?php echo $footer; ?>


### PR DESCRIPTION
#### 1. Objective

To enable & display an Internet Banking payment method (offsite), this PR provides an additional payment extension "Omise Payment Gateway - Internet Banking" to the OpenCart 2.0 branch.

#### 2. Description of change

This PR adds new payment extension to OpenCart.

It also adds minor change on `src/admin/view/template/payment/omise.tpl` to fix misguided comment.

Since OpenCart only supports 1 payment method per 1 payment extension, this PR have to add a new payment extension instead of modifying the existing one. But to minimize changes and complexities, the extension reuses (not duplicates) existing **omise** extension and adds only required feature that is mandatory to offsite.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 2.0.3.1.
- **Omise plugin version**: Omise-OpenCart 2.0.0.1
- **PHP versions**: 7.0.17

**✏️ Details:**

In OpenCart administration page, select "**Extension (Jigsaw icon)**" > "**Payments**" and scroll down. There should be 2 Omise extensions.

Each extensions can be installed independently but "**Omise Payment Gateway - Internet Banking**" cannot be enabled if "**Omise Payment Gateway**" is neither installed nor enabled.

#### 4. Impact of the change

New extension "**Omise Payment Gateway - Internet Banking**" will be displayed on  "**Extension (Jigsaw icon)**" > "**Payments**" page.

<img width="714" alt="admin-extension-payment" src="https://cloud.githubusercontent.com/assets/245383/24235975/5e936c7c-0fd2-11e7-8912-dbaa4d719301.png">

There will be simple setting for this extension.

<img width="400" alt="add-extension-payment-settings" src="https://cloud.githubusercontent.com/assets/245383/24236184/58b5cf06-0fd3-11e7-8161-dd5e7b72dd84.png">

#### 5. Priority of change

Normal.

#### 6. Additional notes

No.