### PR TITLE
Make charge with Internet Banking by passing 'offsite' param & handle callback

### DIFF
--- a/src/admin/model/payment/omise_offsite.php
+++ b/src/admin/model/payment/omise_offsite.php
@@ -1,6 +1,7 @@
 <?php
-class ModelPaymentOmiseOffsite extends Model
-{
+class ModelPaymentOmiseOffsite extends Model {
+    private $_group = 'omise_offsite';
+
     /**
      * Install a table that need to use in Omise Payment Gateway module
      * @return boolean

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -84,7 +84,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
 				echo json_encode(array('error' => 'Cannot find your order, please try again.'));
 			}
 		} else {
-			echo json_encode(array('error' => 'Please select one provider from the list.'));
+			echo json_encode(array('error' => 'Please select a bank from the list.'));
 		}
 	}
 

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -48,7 +48,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
 							"amount"      => OmisePluginHelperCharge::amount($order_info['currency_code'], $order_total),
 							"currency"    => $this->currency->getCode(),
 							"description" => $this->request->post['description'],
-							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
+							"return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
 							"offsite"     => $this->request->post['offsite_provider']
 						),
 						$omise['pkey'],
@@ -103,8 +103,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
 		if ($order_info) {
 			$data = array_merge($data, array(
 				'button_confirm'   => $this->language->get('button_confirm'),
-				'checkout_url'     => $this->url->link('payment/omise_offsite/checkout'),
-				'success_url'      => $this->url->link('checkout/success'),
+				'checkout_url'     => $this->url->link('payment/omise_offsite/checkout', '', 'SSL'),
+				'success_url'      => $this->url->link('checkout/success', '', 'SSL'),
 				'text_config_one'  => trim($this->config->get('text_config_one')),
 				'text_config_two'  => trim($this->config->get('text_config_two')),
 				'orderid'          => date('His') . $this->session->data['order_id'],

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -9,8 +9,9 @@ class ControllerPaymentOmiseOffsite extends Controller {
 		$translate_code = 'error_' . str_replace(' ', '_', strtolower($clue));
 		$translate_msg  = $this->language->get($translate_code);
 
-		if ($translate_code !== $translate_msg)
+		if ($translate_code !== $translate_msg) {
 			return $translate_msg;
+		}
 
 		return $clue;
 	}

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -20,7 +20,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
 	 * @return string(Json)
 	 */
 	public function checkout() {
-		if (isset($this->request->post['offsite_provider'])) {
+		if (!empty($this->request->post['offsite_provider'])) {
 			$this->load->library('omise');
 			$this->load->library('omise-php/lib/Omise');
 			$this->load->model('payment/omise');
@@ -83,7 +83,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
 				echo json_encode(array('error' => 'Cannot find your order, please try again.'));
 			}
 		} else {
-			return 'not authorized';
+			echo json_encode(array('error' => 'Please select one provider from the list.'));
 		}
 	}
 

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -60,16 +60,9 @@
 .secondary-text             { color: #aaa; font-size: 80%; }
 
 .scb { background: #4e2e7f; }
-img.scb { background: url('catalog/view/theme/default/image/omise-offsite-scb.svg') #4e2e7f; }
-
 .ktb { background: #1ba5e1; }
-img.ktb { background: url('catalog/view/theme/default/image/omise-offsite-ktb.svg') #1ba5e1; }
-
 .bay { background: #fec43b; }
-img.bay { background: url('catalog/view/theme/default/image/omise-offsite-bay.svg') #fec43b; }
-
 .bbl { background: #1e4598; }
-img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.svg') #1e4598; }
 </style>
 <form id="omise-form-checkout" method="post" action="<?php echo $success_url; ?>">
     <!-- Collect a customer's card -->
@@ -87,7 +80,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
                     <label>
                         <input type="radio" data-omise="offsite_provider" id="omise_offsite_scb" name="offsite_provider" value="internet_banking_scb" />
                         <div class="omise-logo-wrapper scb">
-                            <img class="scb" />
+                            <img src="catalog/view/theme/default/image/omise-offsite-scb.svg" class="scb" />
                         </div>
                         <div class="omise-banking-text-wrapper">
                             <span class="title">Siam Commercial Bank</span><br/>
@@ -104,7 +97,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
                     <label>
                         <input type="radio" data-omise="offsite_provider" id="omise_offsite_ktb" name="offsite_provider" value="internet_banking_ktb" />
                         <div class="omise-logo-wrapper ktb">
-                            <img class="ktb" />
+                            <img src="catalog/view/theme/default/image/omise-offsite-ktb.svg" class="ktb" />
                         </div>
                         <div class="omise-banking-text-wrapper">
                             <span class="title">Krungthai Bank</span><br/>
@@ -121,7 +114,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
                     <label>
                         <input type="radio" data-omise="offsite_provider" id="omise_offsite_bay" name="offsite_provider" value="internet_banking_bay" />
                         <div class="omise-logo-wrapper bay">
-                            <img class="bay" />
+                            <img src="catalog/view/theme/default/image/omise-offsite-bay.svg" class="bay" />
                         </div>
                         <div class="omise-banking-text-wrapper">
                             <span class="title">Krungsri Bank</span><br/>
@@ -138,7 +131,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
                     <label>
                         <input type="radio" data-omise="offsite_provider" id="omise_offsite_bbl" name="offsite_provider" value="internet_banking_bbl" />
                         <div class="omise-logo-wrapper bbl">
-                            <img class="bbl" />
+                            <img src="catalog/view/theme/default/image/omise-offsite-bbl.svg" class="bbl" />
                         </div>
                         <div class="omise-banking-text-wrapper">
                             <span class="title">Bangkok Bank</span><br/>

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -18,7 +18,7 @@
 
         // Charge with internet banking.
         var posting = $.post("<?php echo $checkout_url; ?>", {
-            "offsite_provider": form.find("[data-omise=offsite_provider]").val(),
+            "offsite_provider": form.find("[data-omise=offsite_provider]:checked").val(),
             "description": "Charge an internet banking from OpenCart that order id is <?php echo $orderid; ?> from <?php echo $billemail; ?>"
         });
 

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -1,3 +1,57 @@
+<!-- Include Omise's javascript -->
+<script type="text/javascript">
+    $("#omise-form-checkout").submit(function() {
+        var form            = $(this),
+            alertSuccess    = form.find(".alert-success"),
+            alertError      = form.find(".alert-error"),
+            spinner         = form.find('.omise-submitting');
+
+        // Show spinner icon.
+        spinner.addClass('loading');
+
+        // Hidden alert box
+        alertError.removeClass('show');
+        alertSuccess.removeClass('show');
+
+        // Disable the submit button to avoid repeated click.
+        form.find("input[type=submit]").prop("disabled", true);
+
+        // Charge with internet banking.
+        var posting = $.post("<?php echo $checkout_url; ?>", {
+            "offsite_provider": form.find("[data-omise=offsite_provider]").val(),
+            "description": "Charge an internet banking from OpenCart that order id is <?php echo $orderid; ?> from <?php echo $billemail; ?>"
+        });
+
+        posting
+            .done(function(resp) {
+                spinner.removeClass('loading');
+                resp = JSON.parse(resp);
+
+                if (typeof resp === "object") {
+                    if (typeof resp.error !== "undefined") {
+                        alertError.html(resp.error).addClass('show');
+                    } else {
+                        if (typeof resp.redirect !== "undefined") {
+                            console.log('redirect');
+                            window.location = resp.redirect;
+                        } else {
+                            form.get(0).submit();
+                        }
+                    }
+                }
+
+                form.find("input[type=submit]").prop("disabled", false);
+            })
+            .fail(function(jqXHR, textStatus, errorThrown) {
+                spinner.removeClass('loading');
+                alertError.html("Omise "+errorThrown).addClass('show');
+                form.find("input[type=submit]").prop("disabled", false);
+            });
+
+        // Prevent the form from being submitted;
+        return false;
+    });
+</script>
 <!-- Omise's checkout form -->
 <style>
 .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }


### PR DESCRIPTION
**This PR requires #40 to be merged first.**

#### 1. Objective

To make charge with Internet Banking payment method and handle the callback.

#### 2. Description of change

Once a user select an internet banking provider and click the submit button, the page will use XHR to call the checkout method of the offsite extension. The extension then adds order to the database with pending state and calls Omise `charge` API with `offsite` parameter (see https://www.omise.co/offsite-payment) and returns `authorize_uri` to the front end.

The front end will then redirect user to bank authorize page, allowing users to enter their credentials and it will redirect back to OpenCart offsite extension's callback page. The callback page checks for payment result and update order status to either success or failed, then redirects user to the appropriated page.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 2.0.3.1.
- **Omise plugin version**: Omise-OpenCart 2.0.0.1
- **PHP versions**: 7.0.17

**✏️ Details:**

- Buy some item.
- Select the "**Internet Banking (Powered by Omise)**" payment method, accept T&C, and click continue.
- Select any bank, and click confirm order.
- Process at the authorize screen.
- Wait for success/failure result.
- There should be a new capture object in Omise dashboard.

<img width="971" alt="new-charge" src="https://cloud.githubusercontent.com/assets/245383/24238085/97f53a64-0fdb-11e7-97ae-069c13bd7057.png">

<img width="735" alt="charge-info" src="https://cloud.githubusercontent.com/assets/245383/24238087/98d2373e-0fdb-11e7-8028-64b3cc47a909.png">

#### 4. Impact of the change

This PR changes no UI. But make the flow success.

#### 5. Priority of change

Normal.

#### 6. Additional notes

**This PR requires #40 to be merged first.**