### PR TITLE
Make charge with Internet Banking by passing 'offsite' param & handle callback

### DIFF
--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -31,6 +31,16 @@ class ModelPaymentOmise extends Model
                 `test_mode` tinyint NOT NULL DEFAULT 0,
                 PRIMARY KEY `id` (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
 
+            /* Install omise_charge table */
+            $this->db->query(
+                "CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "omise_charge` (
+                    `id` INT(11) NOT NULL AUTO_INCREMENT,
+                    `order_id` INT(11) NOT NULL,
+                    `omise_charge_id` CHAR(45) NOT NULL,
+                    `date_added` DATETIME NOT NULL,
+                    PRIMARY KEY (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
+
             // Insert seed data into table.
             $this->db->query("INSERT INTO `" .DB_PREFIX. "omise_gateway` 
                 (`id`, `public_key`, `secret_key`, `public_key_test`, `secret_key_test`, `test_mode`)

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -112,10 +112,10 @@ class ControllerPaymentOmise extends Controller {
                     // Try to create a charge and capture it.
                     $omise_charge = OmiseCharge::create(
                         array(
-                            "amount"        => formatChargeAmount($order_info['currency_code'], $order_total),
-                            "currency"      => $order_info['currency_code'],
-                            "description"   => $this->request->post['description'],
-                            "card"          => $this->request->post['omise_token']
+                            'amount'        => formatChargeAmount($order_info['currency_code'], $order_total),
+                            'currency'      => $order_info['currency_code'],
+                            'description'   => $this->request->post['description'],
+                            'card'          => $this->request->post['omise_token']
                         ),
                         $omise['public_key'],
                         $omise['secret_key']
@@ -171,7 +171,7 @@ class ControllerPaymentOmise extends Controller {
      */
     public function getYears() {
         $years = array();
-        $first = date("Y");
+        $first = date('Y');
 
         for ($index = 0; $index <= 10; $index++) {
             $year = $first + $index;

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -53,7 +53,7 @@ class ControllerPaymentOmise extends Controller {
 
         $this->document->setTitle($this->language->get('heading_title'));
 
-        $this->data['heading_title'] = $this->language->get('heading_title');
+        $this->data['heading_title']       = $this->language->get('heading_title');
         $this->data['text_payment_failed'] = $this->language->get('text_payment_failed');
 
         if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_failure.tpl')) {
@@ -113,10 +113,10 @@ class ControllerPaymentOmise extends Controller {
                     // Try to create a charge and capture it.
                     $omise_charge = OmiseCharge::create(
                         array(
-                            'amount'        => formatChargeAmount($order_info['currency_code'], $order_total),
-                            'currency'      => $order_info['currency_code'],
-                            'description'   => $this->request->post['description'],
-                            'card'          => $this->request->post['omise_token']
+                            'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
+                            'currency'    => $order_info['currency_code'],
+                            'description' => $this->request->post['description'],
+                            'card'        => $this->request->post['omise_token']
                         ),
                         $omise['public_key'],
                         $omise['secret_key']
@@ -132,10 +132,10 @@ class ControllerPaymentOmise extends Controller {
 
                     echo json_encode(
                         array(
-                            'failure_code'      => $omise_charge['failure_code'],
-                            'failure_message'   => $omise_charge['failure_message'],
-                            'captured'          => $omise_charge['captured'],
-                            'omise'             => $omise_charge
+                            'failure_code'    => $omise_charge['failure_code'],
+                            'failure_message' => $omise_charge['failure_message'],
+                            'captured'        => $omise_charge['captured'],
+                            'omise'           => $omise_charge
                         )
                     );
                 } catch (Exception $e) {
@@ -203,38 +203,38 @@ class ControllerPaymentOmise extends Controller {
             $omise['secret_key'] = $omise['secret_key_test'];
         }
 
-        $this->data['button_confirm']   = $this->language->get('button_confirm');
-        $this->data['checkout_url']     = $this->url->link('payment/omise/checkout', '', 'SSL');
-        $this->data['success_url']      = $this->url->link('checkout/success', '', 'SSL');
+        $this->data['button_confirm'] = $this->language->get('button_confirm');
+        $this->data['checkout_url']   = $this->url->link('payment/omise/checkout', '', 'SSL');
+        $this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
 
         $this->load->model('checkout/order');
         $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
 
         if ($order_info) {
-            $this->data['text_config_one']      = trim($this->config->get('text_config_one')); 
-            $this->data['text_config_two']      = trim($this->config->get('text_config_two')); 
-            $this->data['orderid']              = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']          = $this->url->link('payment/custom/callback', '', 'SSL');
-            $this->data['orderdate']            = date('YmdHis');
-            $this->data['currency']             = $order_info['currency_code'];
-            $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);
-            $this->data['billemail']            = $order_info['email'];
-            $this->data['billphone']            = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['billaddress']          = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['billcountry']          = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['billprovince']         = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
-            $this->data['billcity']             = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['billpost']             = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryname']         = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryaddress']      = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycity']         = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycountry']      = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryprovince']     = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryemail']        = $order_info['email'];
-            $this->data['deliveryphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverypost']         = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
-            
-            $this->data['omise']                = $omise;
+            $this->data['text_config_one']  = trim($this->config->get('text_config_one'));
+            $this->data['text_config_two']  = trim($this->config->get('text_config_two'));
+            $this->data['orderid']          = date('His') . $this->session->data['order_id'];
+            $this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
+            $this->data['orderdate']        = date('YmdHis');
+            $this->data['currency']         = $order_info['currency_code'];
+            $this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);
+            $this->data['billemail']        = $order_info['email'];
+            $this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+            $this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+            $this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
+            $this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
+            $this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+            $this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryemail']    = $order_info['email'];
+            $this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+
+            $this->data['omise']            = $omise;
 
             if (file_exists(DIR_TEMPLATE.$this->config->get('config_template') . '/template/payment/omise.tpl')) {
                 $this->template = $this->config->get('config_template') . '/template/payment/omise.tpl';

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -2,7 +2,7 @@
 
 // Define 'OMISE_USER_AGENT_SUFFIX'
 if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
-    define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/'.VERSION);
+    define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/' . VERSION);
 
 // Define 'OMISE_API_VERSION'
 if(!defined('OMISE_API_VERSION'))
@@ -236,7 +236,7 @@ class ControllerPaymentOmise extends Controller {
 
             $this->data['omise']            = $omise;
 
-            if (file_exists(DIR_TEMPLATE.$this->config->get('config_template') . '/template/payment/omise.tpl')) {
+            if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise.tpl')) {
                 $this->template = $this->config->get('config_template') . '/template/payment/omise.tpl';
             } else {
                 $this->template = 'default/template/payment/omise.tpl';

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -1,12 +1,14 @@
 <?php
 
 // Define 'OMISE_USER_AGENT_SUFFIX'
-if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
+if (!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION')) {
     define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/' . VERSION);
+}
 
 // Define 'OMISE_API_VERSION'
-if(!defined('OMISE_API_VERSION'))
+if (!defined('OMISE_API_VERSION')) {
     define('OMISE_API_VERSION', '2014-07-27');
+}
 
 class ControllerPaymentOmise extends Controller {
     public function checkoutCallback() {

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -182,7 +182,7 @@ class ControllerPaymentOmise extends Controller {
         }
         return $years;
     }
-    
+
     /**
      * Omise card information form
      *
@@ -243,7 +243,7 @@ class ControllerPaymentOmise extends Controller {
             } else {
                 $this->template = 'default/template/payment/omise.tpl';
             }
-            
+
             $this->render();
         }
     }

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -157,8 +157,8 @@ class ControllerPaymentOmise extends Controller {
      */
     public function getMonths() {
         $months = array();
-        for ($index=1; $index <= 12; $index++) {
-            $month = ($index < 10) ? '0'.$index : $index;
+        for ($index = 1; $index <= 12; $index++) {
+            $month = ($index < 10) ? '0' . $index : $index;
             $months[$month] = $month;
         }
         return $months;
@@ -173,7 +173,7 @@ class ControllerPaymentOmise extends Controller {
         $years = array();
         $first = date("Y");
 
-        for ($index=0; $index <= 10; $index++) {
+        for ($index = 0; $index <= 10; $index++) {
             $year = $first + $index;
             $years[$year] = $year;
         }

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -36,11 +36,11 @@ class ControllerPaymentOmise extends Controller
             if ($omise_charge && $omise_charge['authorized'] && $omise_charge['captured']) {
                 // Status: processed.
                 $this->model_checkout_order->confirm($order_id, 15);
-                $this->response->redirect($this->url->link('checkout/success'));
+                $this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
             } else {
                 // Status: failed.
                 $this->model_checkout_order->confirm($order_id, 10);
-                $this->response->redirect($this->url->link('payment/omise/failure'));
+                $this->response->redirect($this->url->link('payment/omise/failure', '', 'SSL'));
             }
         }
 
@@ -208,8 +208,8 @@ class ControllerPaymentOmise extends Controller
         }
 
         $this->data['button_confirm']   = $this->language->get('button_confirm');
-        $this->data['checkout_url']     = $this->url->link('payment/omise/checkout');
-        $this->data['success_url']      = $this->url->link('checkout/success');
+        $this->data['checkout_url']     = $this->url->link('payment/omise/checkout', '', 'SSL');
+        $this->data['success_url']      = $this->url->link('checkout/success', '', 'SSL');
 
         $this->load->model('checkout/order');
         $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
@@ -218,7 +218,7 @@ class ControllerPaymentOmise extends Controller
             $this->data['text_config_one']      = trim($this->config->get('text_config_one')); 
             $this->data['text_config_two']      = trim($this->config->get('text_config_two')); 
             $this->data['orderid']              = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']          = $this->url->link('payment/custom/callback');
+            $this->data['callbackurl']          = $this->url->link('payment/custom/callback', '', 'SSL');
             $this->data['orderdate']            = date('YmdHis');
             $this->data['currency']             = $order_info['currency_code'];
             $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -8,10 +8,8 @@ if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
 if(!defined('OMISE_API_VERSION'))
     define('OMISE_API_VERSION', '2014-07-27');
 
-class ControllerPaymentOmise extends Controller
-{
-    public function checkoutCallback()
-    {
+class ControllerPaymentOmise extends Controller {
+    public function checkoutCallback() {
         if ($this->request->get['order_id']) {
             // Load `omise-php` library.
             $this->load->library('omise/omise-php/lib/Omise');
@@ -80,8 +78,7 @@ class ControllerPaymentOmise extends Controller
      * Checkout orders and charge a card process
      * @return string(Json)
      */
-    public function checkout()
-    {
+    public function checkout() {
         // If has a `post['omise_token']` request.
         if (isset($this->request->post['omise_token'])) {
             $this->load->helper('omise_currency');
@@ -158,8 +155,7 @@ class ControllerPaymentOmise extends Controller
      *
      * @return array
      */
-    public function getMonths()
-    {
+    public function getMonths() {
         $months = array();
         for ($index=1; $index <= 12; $index++) {
             $month = ($index < 10) ? '0'.$index : $index;
@@ -173,8 +169,7 @@ class ControllerPaymentOmise extends Controller
      *
      * @return array
      */
-    public function getYears()
-    {
+    public function getYears() {
         $years = array();
         $first = date("Y");
 
@@ -189,8 +184,7 @@ class ControllerPaymentOmise extends Controller
      * Omise card information form
      * @return void
      */
-    protected function index()
-    {
+    protected function index() {
         /**
          * Prepare and loading necessary scripts.
          *

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -76,6 +76,7 @@ class ControllerPaymentOmise extends Controller {
 
     /**
      * Checkout orders and charge a card process
+     *
      * @return string(Json)
      */
     public function checkout() {
@@ -182,6 +183,7 @@ class ControllerPaymentOmise extends Controller {
     
     /**
      * Omise card information form
+     *
      * @return void
      */
     protected function index() {

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -73,11 +73,11 @@ class ControllerPaymentOmiseOffsite extends Controller {
 
                     echo json_encode(
                         array(
-                            'failure_code'      => $omise_charge['failure_code'],
-                            'failure_message'   => $omise_charge['failure_message'],
-                            'captured'          => $omise_charge['captured'],
-                            'omise'             => $omise_charge,
-                            'redirect'          => $omise_charge['authorize_uri']
+                            'failure_code'    => $omise_charge['failure_code'],
+                            'failure_message' => $omise_charge['failure_message'],
+                            'captured'        => $omise_charge['captured'],
+                            'omise'           => $omise_charge,
+                            'redirect'        => $omise_charge['authorize_uri']
                         )
                     );
                 } catch (Exception $e) {
@@ -107,36 +107,36 @@ class ControllerPaymentOmiseOffsite extends Controller {
         $this->language->load('payment/omise');
         $this->language->load('payment/omise_offsite');
 
-        $this->data['button_confirm']   = $this->language->get('button_confirm');
-        $this->data['checkout_url']     = $this->url->link('payment/omise_offsite/checkout', '', 'SSL');
-        $this->data['success_url']      = $this->url->link('checkout/success', '', 'SSL');
+        $this->data['button_confirm'] = $this->language->get('button_confirm');
+        $this->data['checkout_url']   = $this->url->link('payment/omise_offsite/checkout', '', 'SSL');
+        $this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
 
         $this->load->model('checkout/order');
         $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
 
         if ($order_info) {
-            $this->data['text_config_one']      = trim($this->config->get('text_config_one'));
-            $this->data['text_config_two']      = trim($this->config->get('text_config_two'));
-            $this->data['orderid']              = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']          = $this->url->link('payment/custom/callback', '', 'SSL');
-            $this->data['orderdate']            = date('YmdHis');
-            $this->data['currency']             = $order_info['currency_code'];
-            $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
-            $this->data['billemail']            = $order_info['email'];
-            $this->data['billphone']            = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['billaddress']          = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['billcountry']          = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['billprovince']         = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
-            $this->data['billcity']             = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['billpost']             = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryname']         = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryaddress']      = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycity']         = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycountry']      = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryprovince']     = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryemail']        = $order_info['email'];
-            $this->data['deliveryphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverypost']         = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+            $this->data['text_config_one']  = trim($this->config->get('text_config_one'));
+            $this->data['text_config_two']  = trim($this->config->get('text_config_two'));
+            $this->data['orderid']          = date('His') . $this->session->data['order_id'];
+            $this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
+            $this->data['orderdate']        = date('YmdHis');
+            $this->data['currency']         = $order_info['currency_code'];
+            $this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
+            $this->data['billemail']        = $order_info['email'];
+            $this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+            $this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+            $this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
+            $this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
+            $this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+            $this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliveryemail']    = $order_info['email'];
+            $this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+            $this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
 
             if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_offsite.tpl')) {
                 $this->template = $this->config->get('config_template') . '/template/payment/omise_offsite.tpl';

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -53,7 +53,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
                             "amount"      => formatChargeAmount($order_info['currency_code'], $order_total),
                             "currency"    => $order_info['currency_code'],
                             "description" => $this->request->post['description'],
-                            "return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
+                            "return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
                             "offsite"     => $this->request->post['offsite_provider']
                         ),
                         $omise['public_key'],
@@ -106,8 +106,8 @@ class ControllerPaymentOmiseOffsite extends Controller {
         $this->language->load('payment/omise_offsite');
 
         $this->data['button_confirm']   = $this->language->get('button_confirm');
-        $this->data['checkout_url']     = $this->url->link('payment/omise_offsite/checkout');
-        $this->data['success_url']      = $this->url->link('checkout/success');
+        $this->data['checkout_url']     = $this->url->link('payment/omise_offsite/checkout', '', 'SSL');
+        $this->data['success_url']      = $this->url->link('checkout/success', '', 'SSL');
 
         $this->load->model('checkout/order');
         $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
@@ -116,7 +116,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
             $this->data['text_config_one']      = trim($this->config->get('text_config_one'));
             $this->data['text_config_two']      = trim($this->config->get('text_config_two'));
             $this->data['orderid']              = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']          = $this->url->link('payment/custom/callback');
+            $this->data['callbackurl']          = $this->url->link('payment/custom/callback', '', 'SSL');
             $this->data['orderdate']            = date('YmdHis');
             $this->data['currency']             = $order_info['currency_code'];
             $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -52,11 +52,11 @@ class ControllerPaymentOmiseOffsite extends Controller {
                     // Try to create a charge and capture it.
                     $omise_charge = OmiseCharge::create(
                         array(
-                            "amount"      => formatChargeAmount($order_info['currency_code'], $order_total),
-                            "currency"    => $order_info['currency_code'],
-                            "description" => $this->request->post['description'],
-                            "return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
-                            "offsite"     => $this->request->post['offsite_provider']
+                            'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
+                            'currency'    => $order_info['currency_code'],
+                            'description' => $this->request->post['description'],
+                            'return_uri'  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
+                            'offsite'     => $this->request->post['offsite_provider']
                         ),
                         $omise['public_key'],
                         $omise['secret_key']

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -3,6 +3,7 @@
 class ControllerPaymentOmiseOffsite extends Controller {
     /**
      * Checkout orders and charge a card process
+     *
      * @return string(Json)
      */
     public function checkout() {

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -121,7 +121,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
             $this->data['callbackurl']          = $this->url->link('payment/custom/callback', '', 'SSL');
             $this->data['orderdate']            = date('YmdHis');
             $this->data['currency']             = $order_info['currency_code'];
-            $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);
+            $this->data['orderamount']          = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
             $this->data['billemail']            = $order_info['email'];
             $this->data['billphone']            = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
             $this->data['billaddress']          = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -8,12 +8,14 @@ class ControllerPaymentOmiseOffsite extends Controller {
      */
     public function checkout() {
         // Define 'OMISE_USER_AGENT_SUFFIX'
-        if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/'.VERSION);
+        if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION')) {
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/' . VERSION);
+        }
 
         // Define 'OMISE_API_VERSION'
-        if(!defined('OMISE_API_VERSION'))
+        if(!defined('OMISE_API_VERSION')) {
             define('OMISE_API_VERSION', '2014-07-27');
+        }
 
         // If has a `post['omise_token']` request.
         if (!empty($this->request->post['offsite_provider'])) {

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -2,6 +2,96 @@
 
 class ControllerPaymentOmiseOffsite extends Controller {
     /**
+     * Checkout orders and charge a card process
+     * @return string(Json)
+     */
+    public function checkout()
+    {
+        // Define 'OMISE_USER_AGENT_SUFFIX'
+        if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/'.VERSION);
+
+        // Define 'OMISE_API_VERSION'
+        if(!defined('OMISE_API_VERSION'))
+            define('OMISE_API_VERSION', '2014-07-27');
+
+        // If has a `post['omise_token']` request.
+        if (!empty($this->request->post['offsite_provider'])) {
+            $this->load->helper('omise_currency');
+
+            // Load `omise-php` library.
+            $this->load->library('omise/omise-php/lib/Omise');
+
+            // Get Omise configuration.
+            $omise = $this->config->get('Omise');
+
+            // If test mode was enabled,
+            // replace Omise live key with test key.
+            if (isset($omise['test_mode']) && $omise['test_mode']) {
+                $omise['public_key'] = $omise['public_key_test'];
+                $omise['secret_key'] = $omise['secret_key_test'];
+            }
+
+            // Create a order history with `Processing` status
+            $this->load->model('checkout/order');
+            $this->load->model('payment/omise');
+
+            $order_id    = $this->session->data['order_id'];
+            $order_info  = $this->model_checkout_order->getOrder($order_id);
+            $order_total = $this->currency->format(
+                $order_info['total'],
+                $order_info['currency_code'],
+                $order_info['currency_value'],
+                false
+            );
+
+            if ($order_info) {
+                try {
+                    // Try to create a charge and capture it.
+                    $omise_charge = OmiseCharge::create(
+                        array(
+                            "amount"      => formatChargeAmount($order_info['currency_code'], $order_total),
+                            "currency"    => $order_info['currency_code'],
+                            "description" => $this->request->post['description'],
+                            "return_uri"  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id),
+                            "offsite"     => $this->request->post['offsite_provider']
+                        ),
+                        $omise['public_key'],
+                        $omise['secret_key']
+                    );
+
+                    if (is_null($omise_charge['failure_code']) && is_null($omise_charge['failure_code'])) {
+                        // Status: processing.
+                        $this->model_payment_omise->addChargeTransaction($order_id, $omise_charge['id']);
+                        $this->model_checkout_order->update($order_id, 2);
+                    } else {
+                        // Status: failed.
+                        $this->model_checkout_order->update($order_id, 10);
+                    }
+
+                    echo json_encode(
+                        array(
+                            'failure_code'      => $omise_charge['failure_code'],
+                            'failure_message'   => $omise_charge['failure_message'],
+                            'captured'          => $omise_charge['captured'],
+                            'omise'             => $omise_charge,
+                            'redirect'          => $omise_charge['authorize_uri']
+                        )
+                    );
+                } catch (Exception $e) {
+                    // Status: failed.
+                    $this->model_checkout_order->update($this->session->data['order_id'], 10);
+                    echo json_encode(array('error' => $e->getMessage()));
+                }
+            } else {
+                echo json_encode(array('error' => 'Cannot find your order, please try again.'));
+            }
+        } else {
+            echo json_encode(array('error' => 'Please select one provider from the list.'));
+        }
+    }
+    
+    /**
      * Omise card information form
      *
      * @return void

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -5,8 +5,7 @@ class ControllerPaymentOmiseOffsite extends Controller {
      * Checkout orders and charge a card process
      * @return string(Json)
      */
-    public function checkout()
-    {
+    public function checkout() {
         // Define 'OMISE_USER_AGENT_SUFFIX'
         if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
             define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.3 OpenCart/'.VERSION);

--- a/src/catalog/language/english/payment/omise.php
+++ b/src/catalog/language/english/payment/omise.php
@@ -1,4 +1,7 @@
 <?php
+$_['heading_title']     = 'Omise Payment Gateway';
 $_['text_title'] 		= 'Credit Card (Powered by Omise)';
 $_['button_confirm'] 	= 'Confirm Order';
+
+$_['text_payment_failed'] = 'Your payment has failed. Please contact the shop administrator for assistance or use a different payment option.';
 ?>

--- a/src/catalog/model/payment/omise.php
+++ b/src/catalog/model/payment/omise.php
@@ -11,4 +11,19 @@ class ModelPaymentOmise extends Model
      
        return $method_data;
      }    
+
+     public function addChargeTransaction($order_id, $charge_id) {
+         $this->db->query(
+             "INSERT INTO `" . DB_PREFIX . "omise_charge` " .
+             "SET order_id = '" . $this->db->escape($order_id) . "', " . 
+             "omise_charge_id = '" . $this->db->escape($charge_id) . "', " .
+             "date_added = NOW()");
+     }
+
+     public function getChargeTransaction($order_id) {
+         return $this->db->query(
+             "SELECT * " .
+             "FROM `" . DB_PREFIX . "omise_charge` " .
+             "WHERE order_id = '" . $this->db->escape($order_id) . "'");
+     }
 }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -17,3 +17,15 @@ form#omise-form-checkout .omise-payment input               { background: #fff; 
 form#omise-form-checkout .alert-box                         { display: none; }
 form#omise-form-checkout .show                              { display: block !important; }
 form#omise-form-checkout .overlay                           { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
+
+/* Offsite */
+form#omise-form-checkout .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; bo
+    rder-radius: 2px; vertical-align: top; }
+form#omise-form-checkout .omise-logo-wrapper img     { width: 30px; height: 30px; }
+form#omise-form-checkout .omise-banking-text-wrapper { display: inline-block; }
+form#omise-form-checkout .secondary-text             { color: #aaa; font-size: 80%; }
+
+form#omise-form-checkout .scb                        { background: #4e2e7f; }
+form#omise-form-checkout .ktb                        { background: #1ba5e1; }
+form#omise-form-checkout .bay                        { background: #fec43b; }
+form#omise-form-checkout .bbl                        { background: #1e4598; }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -3,10 +3,6 @@ form#omise-form-checkout .omise-payment                     { background: #fafaf
 form#omise-form-checkout .omise-payment .left               { width: 13%; padding-left: 2%; }
 form#omise-form-checkout .omise-payment .right              { width: 85%; }
 
-form#omise-form-checkout .omise-payment.offsite .left       { width: auto; padding: 18px 0 0; }
-form#omise-form-checkout .omise-payment.offsite .right      { width: 93%; border-bottom: 1px solid #eee; margin: 0 0 6px 0; padding: 4px 0 12px; float: none; }
-form#omise-form-checkout .omise-payment.offsite input       { width: auto; height: auto; }
-
 form#omise-form-checkout .omise-payment .clearfix:after,
 form#omise-form-checkout .omise-payment .clearfix:before    { display: table; content: " " }
 form#omise-form-checkout .omise-payment .clearfix:after     { clear: both }
@@ -19,6 +15,10 @@ form#omise-form-checkout .show                              { display: block !im
 form#omise-form-checkout .overlay                           { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
 
 /* Offsite */
+form#omise-form-checkout .omise-payment.offsite .left       { width: auto; padding: 18px 0 0; }
+form#omise-form-checkout .omise-payment.offsite .right      { width: 93%; border-bottom: 1px solid #eee; margin: 0 0 6px 0; padding: 4px 0 12px; float: none; }
+form#omise-form-checkout .omise-payment.offsite input       { width: auto; height: auto; }
+
 form#omise-form-checkout .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }
 form#omise-form-checkout .omise-logo-wrapper img     { width: 30px; height: 30px; }
 form#omise-form-checkout .omise-banking-text-wrapper { display: inline-block; }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -15,16 +15,16 @@ form#omise-form-checkout .show                              { display: block !im
 form#omise-form-checkout .overlay                           { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
 
 /* Offsite */
-form#omise-form-checkout .omise-payment.offsite .left       { width: auto; padding: 18px 0 0; }
-form#omise-form-checkout .omise-payment.offsite .right      { width: 93%; border-bottom: 1px solid #eee; margin: 0 0 6px 0; padding: 4px 0 12px; float: none; }
-form#omise-form-checkout .omise-payment.offsite input       { width: auto; height: auto; }
+form#omise-form-checkout .omise-payment.offsite .left  { width: auto; padding: 18px 0 0; }
+form#omise-form-checkout .omise-payment.offsite .right { width: 93%; border-bottom: 1px solid #eee; margin: 0 0 6px 0; padding: 4px 0 12px; float: none; }
+form#omise-form-checkout .omise-payment.offsite input  { width: auto; height: auto; }
 
-form#omise-form-checkout .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }
-form#omise-form-checkout .omise-logo-wrapper img     { width: 30px; height: 30px; }
-form#omise-form-checkout .omise-banking-text-wrapper { display: inline-block; }
-form#omise-form-checkout .secondary-text             { color: #aaa; font-size: 80%; }
+form#omise-form-checkout .omise-logo-wrapper           { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }
+form#omise-form-checkout .omise-logo-wrapper img       { width: 30px; height: 30px; }
+form#omise-form-checkout .omise-banking-text-wrapper   { display: inline-block; }
+form#omise-form-checkout .secondary-text               { color: #aaa; font-size: 80%; }
 
-form#omise-form-checkout .scb                        { background: #4e2e7f; }
-form#omise-form-checkout .ktb                        { background: #1ba5e1; }
-form#omise-form-checkout .bay                        { background: #fec43b; }
-form#omise-form-checkout .bbl                        { background: #1e4598; }
+form#omise-form-checkout .scb                          { background: #4e2e7f; }
+form#omise-form-checkout .ktb                          { background: #1ba5e1; }
+form#omise-form-checkout .bay                          { background: #fec43b; }
+form#omise-form-checkout .bbl                          { background: #1e4598; }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -19,8 +19,7 @@ form#omise-form-checkout .show                              { display: block !im
 form#omise-form-checkout .overlay                           { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
 
 /* Offsite */
-form#omise-form-checkout .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; bo
-    rder-radius: 2px; vertical-align: top; }
+form#omise-form-checkout .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }
 form#omise-form-checkout .omise-logo-wrapper img     { width: 30px; height: 30px; }
 form#omise-form-checkout .omise-banking-text-wrapper { display: inline-block; }
 form#omise-form-checkout .secondary-text             { color: #aaa; font-size: 80%; }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -3,8 +3,9 @@ form#omise-form-checkout .omise-payment                     { background: #fafaf
 form#omise-form-checkout .omise-payment .left               { width: 13%; padding-left: 2%; }
 form#omise-form-checkout .omise-payment .right              { width: 85%; }
 
-form#omise-form-checkout .omise-payment.offsite .left       { width: 5%; padding-left: 2%; }
-form#omise-form-checkout .omise-payment.offsite .right      { width: 93%; }
+form#omise-form-checkout .omise-payment.offsite .left       { width: auto; padding: 18px 0 0; }
+form#omise-form-checkout .omise-payment.offsite .right      { width: 93%; border-bottom: 1px solid #eee; margin: 0 0 6px 0; padding: 4px 0 12px; float: none; }
+form#omise-form-checkout .omise-payment.offsite input       { width: auto; height: auto; }
 
 form#omise-form-checkout .omise-payment .clearfix:after,
 form#omise-form-checkout .omise-payment .clearfix:before    { display: table; content: " " }

--- a/src/catalog/view/stylesheet/omise/omise.css
+++ b/src/catalog/view/stylesheet/omise/omise.css
@@ -1,18 +1,18 @@
-form#omise-form-checkout .omise-payment                     { background: #fafafa; padding: 10px; color: #333; text-shadow: 1px 1px #fff; }
+form#omise-form-checkout .omise-payment                  { background: #fafafa; padding: 10px; color: #333; text-shadow: 1px 1px #fff; }
 
-form#omise-form-checkout .omise-payment .left               { width: 13%; padding-left: 2%; }
-form#omise-form-checkout .omise-payment .right              { width: 85%; }
+form#omise-form-checkout .omise-payment .left            { width: 13%; padding-left: 2%; }
+form#omise-form-checkout .omise-payment .right           { width: 85%; }
 
 form#omise-form-checkout .omise-payment .clearfix:after,
-form#omise-form-checkout .omise-payment .clearfix:before    { display: table; content: " " }
-form#omise-form-checkout .omise-payment .clearfix:after     { clear: both }
-form#omise-form-checkout .omise-payment .input-group        { margin-bottom: 10px; }
-form#omise-form-checkout .omise-payment .left label         { display: table-cell; vertical-align: middle; height: 34px; }
-form#omise-form-checkout .omise-payment input               { background: #fff; border-color: #eee; width: 30%; height: 26px; padding: 3px 8px; }
+form#omise-form-checkout .omise-payment .clearfix:before { display: table; content: " " }
+form#omise-form-checkout .omise-payment .clearfix:after  { clear: both }
+form#omise-form-checkout .omise-payment .input-group     { margin-bottom: 10px; }
+form#omise-form-checkout .omise-payment .left label      { display: table-cell; vertical-align: middle; height: 34px; }
+form#omise-form-checkout .omise-payment input            { background: #fff; border-color: #eee; width: 30%; height: 26px; padding: 3px 8px; }
 
-form#omise-form-checkout .alert-box                         { display: none; }
-form#omise-form-checkout .show                              { display: block !important; }
-form#omise-form-checkout .overlay                           { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
+form#omise-form-checkout .alert-box                      { display: none; }
+form#omise-form-checkout .show                           { display: block !important; }
+form#omise-form-checkout .overlay                        { background: rgba(0, 0, 0, 0.8); width: 100%; height: 100%; position: fixed; top: 0; left: 0; z-index: 100; display: none; }
 
 /* Offsite */
 form#omise-form-checkout .omise-payment.offsite .left  { width: auto; padding: 18px 0 0; }

--- a/src/catalog/view/theme/default/template/payment/omise_failure.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_failure.tpl
@@ -1,0 +1,7 @@
+<?php echo $header; ?><?php echo $column_left; ?><?php echo $column_right; ?>
+<div id="content"><?php echo $content_top; ?>
+  <h2><?php echo $heading_title; ?></h2>
+  <p><?php echo $text_payment_failed ?></p>
+  <?php echo $content_bottom; ?>
+</div>
+<?php echo $footer; ?>

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -62,16 +62,9 @@
 .secondary-text             { color: #aaa; font-size: 80%; }
 
 .scb { background: #4e2e7f; }
-img.scb { background: url('catalog/view/theme/default/image/omise-offsite-scb.svg') #4e2e7f; }
-
 .ktb { background: #1ba5e1; }
-img.ktb { background: url('catalog/view/theme/default/image/omise-offsite-ktb.svg') #1ba5e1; }
-
 .bay { background: #fec43b; }
-img.bay { background: url('catalog/view/theme/default/image/omise-offsite-bay.svg') #fec43b; }
-
 .bbl { background: #1e4598; }
-img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.svg') #1e4598; }
 </style>
 <form id="omise-form-checkout" method="post" action="<?php echo $success_url; ?>">
     <img src="catalog/view/theme/default/image/secured_by_omise.png" width="200">
@@ -88,7 +81,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
             <div class="left"><input type="radio" data-omise="offsite_provider" id="omise_offsite_scb" name="offsite_provider" value="internet_banking_scb" /></div>
             <div class="right">
                 <div class="omise-logo-wrapper scb">
-                    <img class="scb" />
+                    <img src="catalog/view/theme/default/image/omise-offsite-scb.svg" class="scb" />
                 </div>
                 <div class="omise-banking-text-wrapper">
                     <span class="title">Siam Commercial Bank</span><br/>
@@ -101,7 +94,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
             <div class="left"><input type="radio" data-omise="offsite_provider" id="omise_offsite_ktb" name="offsite_provider" value="internet_banking_ktb" /></div>
             <div class="right">
                 <div class="omise-logo-wrapper ktb">
-                    <img class="ktb" />
+                    <img src="catalog/view/theme/default/image/omise-offsite-ktb.svg" class="ktb" />
                 </div>
                 <div class="omise-banking-text-wrapper">
                     <span class="title">Krungthai Bank</span><br/>
@@ -114,7 +107,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
             <div class="left"><input type="radio" data-omise="offsite_provider" id="omise_offsite_bay" name="offsite_provider" value="internet_banking_bay" /></div>
             <div class="right">
                 <div class="omise-logo-wrapper bay">
-                    <img class="bay" />
+                    <img src="catalog/view/theme/default/image/omise-offsite-bay.svg" class="bay" />
                 </div>
                 <div class="omise-banking-text-wrapper">
                     <span class="title">Krungsri Bank</span><br/>
@@ -127,7 +120,7 @@ img.bbl { background: url('catalog/view/theme/default/image/omise-offsite-bbl.sv
             <div class="left"><input type="radio" data-omise="offsite_provider" id="omise_offsite_bbl" name="offsite_provider" value="internet_banking_bbl" /></div>
             <div class="right">
                 <div class="omise-logo-wrapper bbl">
-                    <img class="bbl" />
+                    <img src="catalog/view/theme/default/image/omise-offsite-bbl.svg" class="bbl" />
                 </div>
                 <div class="omise-banking-text-wrapper">
                     <span class="title">Bangkok Bank</span><br/>

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -1,6 +1,59 @@
 <!-- Include Omise's stylesheet -->
 <link rel="stylesheet" type="text/css" href="catalog/view/stylesheet/omise/omise.css">
 
+<!-- Include Omise's javascript -->
+<script type="text/javascript">
+    $("#omise-form-checkout").submit(function() {
+        var form            = $(this),
+            alertSuccess    = form.find(".alert-success"),
+            alertError      = form.find(".alert-error"),
+            overlay         = form.find('.overlay');
+
+        // Show loading overlay.
+        overlay.addClass('show');
+
+        // Disable the submit button to avoid repeated click.
+        form.find("input[type=submit]").prop("disabled", true);
+
+        // Hidden alert box
+        alertError.removeClass('show');
+        alertSuccess.removeClass('show');
+
+        // Charge with internet banking.
+        var posting = $.post("<?php echo $checkout_url; ?>", {
+            "offsite_provider": form.find("[data-omise=offsite_provider]:checked").val(),
+            "description": "Charge an internet banking from OpenCart that order id is <?php echo $orderid; ?> from <?php echo $billemail; ?>"
+        });
+
+        posting
+            .done(function(resp) {
+                overlay.removeClass('show');
+                resp = JSON.parse(resp);
+
+                if (typeof resp.error !== "undefined") {
+                    alertError.html("Omise Response: "+resp.error).addClass('show');
+                } else if (resp.failure_code != null) {
+                    alertError.html("Bank Response: "+resp.failure_message).addClass('show');
+                } else if (typeof resp.redirect !== "undefined") {
+                    console.log('redirect');
+                    window.location = resp.redirect;
+                } else {
+                    alertSuccess.html("Succeed").addClass('show');
+                    form.get(0).submit();
+                }
+
+                form.find("input[type=submit]").prop("disabled", false);
+            })
+            .fail(function(jqXHR, textStatus, errorThrown) {
+                overlay.removeClass('show');
+                alertError.html("Omise "+errorThrown).addClass('show');
+                form.find("input[type=submit]").prop("disabled", false);
+            });
+
+        // Prevent the form from being submitted;
+        return false;
+    });
+</script>
 <!-- Omise's checkout form -->
 <style>
 .omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }

--- a/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_offsite.tpl
@@ -54,18 +54,6 @@
         return false;
     });
 </script>
-<!-- Omise's checkout form -->
-<style>
-.omise-logo-wrapper         { display: inline-block; padding: 5px; margin: 0 10px; border-radius: 2px; vertical-align: top; }
-.omise-logo-wrapper img     { width: 30px; height: 30px; }
-.omise-banking-text-wrapper { display: inline-block; }
-.secondary-text             { color: #aaa; font-size: 80%; }
-
-.scb { background: #4e2e7f; }
-.ktb { background: #1ba5e1; }
-.bay { background: #fec43b; }
-.bbl { background: #1e4598; }
-</style>
 <form id="omise-form-checkout" method="post" action="<?php echo $success_url; ?>">
     <img src="catalog/view/theme/default/image/secured_by_omise.png" width="200">
     <!-- Collect a customer's card -->


### PR DESCRIPTION
**This PR requires #43 to be merged first.**

#### 1. Objective

To make charge with Internet Banking payment method and handle the callback.

#### 2. Description of change

Once a user select an internet banking provider and click the submit button, the page will use XHR to call the checkout method of the offsite extension. The extension then adds order to the database with pending state and calls Omise `charge` API with `offsite` parameter (see https://www.omise.co/offsite-payment) and returns `authorize_uri` to the front end.

The front end will then redirect user to bank authorize page, allowing users to enter their credentials and it will redirect back to OpenCart offsite extension's callback page. The callback page checks for payment result and update order status to either success or failed, then redirects user to the appropriated page.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 1.5.6.4
- **Omise plugin version**: Omise-OpenCart 1.3
- **PHP versions**: 5.6.30

**✏️ Details:**

- Buy some item.
- Select the "**Internet Banking (Powered by Omise)**" payment method, accept T&C, and click continue.
- Select any bank, and click confirm order.
- Process at the authorize screen.
- Wait for success/failure result.
- There should be a new capture object in Omise dashboard.

<img width="971" alt="new-charge" src="https://cloud.githubusercontent.com/assets/245383/24238085/97f53a64-0fdb-11e7-97ae-069c13bd7057.png">

<img width="735" alt="charge-info" src="https://cloud.githubusercontent.com/assets/245383/24238087/98d2373e-0fdb-11e7-8028-64b3cc47a909.png">

#### 4. Impact of the change

This PR changes no UI. But make the flow success.

#### 5. Priority of change

Normal.

#### 6. Additional notes

**This PR requires #43 to be merged first.**