### PR TITLE
Apply OpenCart coding standard

### DIFF
--- a/.phpcs/OpenCart/ruleset.xml
+++ b/.phpcs/OpenCart/ruleset.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<ruleset name="OpenCart">
+    <description>The Code Sniffer rule set for OpenCart</description>
+
+    <exclude-pattern>*/system/vendor/*</exclude-pattern>
+
+    <rule ref="Squiz.ControlStructures.InlineIfDeclaration" />
+
+    <!-- Closing PHP tags are not allowed -->
+    <!-- All PHP files must include a closing tag for versions before 2.0.
+         PHP files in and after 2.0 will no longer have a closing tag. -->
+    <!--
+    <rule ref="Zend.Files.ClosingTag">
+        <severity>5</severity>
+        <type>error</type>
+    </rule>
+    -->
+
+    <!-- Test the spacing of inline control statements -->
+    <rule ref="Squiz.ControlStructures.InlineIfDeclaration" />
+
+    <!-- Opening curly braces do not go onto a new line -->
+    <rule ref="Generic.Classes.OpeningBraceSameLine" />
+    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+
+    <!-- Check for whitespace after lines of code and checks for spaces/indents on empty lines -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <severity>1</severity>
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile" />
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile" />
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+
+    <!-- Check to ensure no PHP deprecated functions have been used -->
+    <rule ref="Generic.PHP.DeprecatedFunctions">
+        <severity>5</severity>
+        <type>error</type>
+    </rule>
+
+    <!-- PHP opening tag must be full <?php, no shorthand or ASP tags -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag">
+        <severity>5</severity>
+        <type>error</type>
+    </rule>
+
+    <!-- In PHP files make sure there is no character before the opening tag -->
+    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
+
+    <!-- true, false, null etc should all be lowercase only -->
+    <rule ref="Generic.PHP.LowerCaseConstant" />
+
+    <!-- Type casting should be immediately followed by the variable, no space -->
+    <rule ref="Generic.Formatting.NoSpaceAfterCast" />
+
+    <!-- Pass by reference is now only supported in the method/function params -->
+    <rule ref="Generic.Functions.CallTimePassByReference" />
+
+    <!-- keep the spacing between function/method params space after comma -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
+
+    <!-- method names should always be camel case -->
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
+
+    <!-- constants should always be uppercase -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+
+    <!-- Detect BOMs to avoid curruptions -->
+    <rule ref="Generic.Files.ByteOrderMark"/>
+
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent">
+        <exclude-pattern>*.tpl</exclude-pattern>
+        <exclude-pattern>*.css</exclude-pattern>
+        <exclude-pattern>*.html</exclude-pattern>
+        <exclude-pattern>*.ini</exclude-pattern>
+        <exclude-pattern>*.txt</exclude-pattern>
+        <severity>1</severity>
+        <type>warning</type>
+    </rule>
+
+    <!-- To do comments should be reported and completed -->
+    <rule ref="Generic.Commenting.Todo.CommentFound">
+        <message>Please review this TODO comment: %s</message>
+        <severity>3</severity>
+        <type>warning</type>
+    </rule>
+
+    <!-- Fix me comments should be reported and fixed -->
+    <rule ref="Generic.Commenting.Todo.Fixme">
+        <message>Please review this FIXME comment: %s</message>
+        <severity>5</severity>
+        <type>warning</type>
+    </rule>
+
+    <!-- Check that line endings are only \n -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
+
+    <!-- <rule ref="Squiz.ControlStructures.ControlSignature" /> -->
+    <!-- <rule ref="Generic.ControlStructures.InlineControlStructure"></rule> -->
+
+    <!-- exclude the actual tests directory from being tested! -->
+    <exclude-pattern>*/tests/*</exclude-pattern>
+</ruleset>
+
+<!-- @todo - A Sniff test needs to be added to ensure short echo tags are not used -->
+<!-- @todo - A Sniff test to allow helper functions (normal functions) to be snake case -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+[1.5] pending
+---
+- *`Updated`* Reformat the PHP files under `src/admin` & `src/catalog` by follow the OpenCart Coding standards
+
 [1.4] 2017-04-04
 ---
 - *`Added`* Support for [Internet Banking](https://www.omise.co/offsite-payment)

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="OpenCart">
+    <exclude-pattern>src/omise-opencart/*</exclude-pattern>
+    <exclude-pattern>src/system/*</exclude-pattern>
+    <rule ref=".phpcs/OpenCart"/>
+</ruleset>

--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -1,498 +1,480 @@
 <?php
 
-class ControllerPaymentOmise extends Controller
-{
-    /**
-     * $error
-     *
-     */
-    private $error = array();
-
-    /**
-     * Render Omise Payment Gateway dashboard page
-     * @return void
-     */
-    public function dashboard()
-    {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        $this->load->helper('omise_currency');
-
-        // Load model.
-        $this->load->model('payment/omise');
-
-        // Load language.
-        $this->language->load('payment/omise');
-
-
-        /**
-         * Language setup.
-         *
-         */
-        $this->document->setTitle($this->language->get('dashboard_page_title'));
-
-        // Set page's component label with language.
-        $this->data['heading_title']            = $this->language->get('dashboard_heading_title');
-        $this->data['setting_url']              = $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL');
-        $this->data['setting_button_title']     = $this->language->get('text_button_setting');
-        $this->data['transfer_url']             = $this->url->link('payment/omise/submittransfer', 'token=' . $this->session->data['token'], 'SSL');
-
-
-        /**
-         * Page data setup.
-         *
-         */
-        $this->data['omise'] = array();
-
-        // Check Omise extension is enabled.
-        if (!$this->config->get('omise_status')) {
-            $this->session->data['error'] = $this->language->get('error_extension_disabled');
-        } else {
-            try {
-                // Retrieve Omise Account.
-                $omise_account = $this->model_payment_omise->getOmiseAccount();
-                if (isset($omise_account['error']))
-                    throw new Exception('Omise Account:: '.$omise_account['error'], 1);
-
-                $this->data['omise']['account']['email']    = $omise_account['email'];
-                $this->data['omise']['account']['created']  = $omise_account['created'];
-
-                // Retrieve Omise Balance.
-                $omise_balance = $this->model_payment_omise->getOmiseBalance();
-                if (isset($omise_balance['error']))
-                    throw new Exception('Omise Balance:: '.$omise_balance['error'], 1);
-
-                $this->data['omise']['balance']['livemode']     = $omise_balance['livemode'];
-                $this->data['omise']['balance']['available']    = $omise_balance['available'];
-                $this->data['omise']['balance']['total']        = $omise_balance['total'];
-                $this->data['omise']['balance']['currency']     = $omise_balance['currency'];
-
-                // Retrieve Omise Transfer List.
-                $omise_transfer = $this->model_payment_omise->getOmiseTransferList();
-                if (isset($omise_transfer['error']))
-                    throw new Exception('Omise Transfer:: '.$omise_transfer['error'], 1);
-
-                $this->data['omise']['transfer']['data']        = array_reverse($omise_transfer['data']);
-                $this->data['omise']['transfer']['total']       = $omise_transfer['total'];
-            } catch (Exception $e) {
-                $this->session->data['error'] = $e->getMessage();
-            }
-        }
-
-
-        /**
-         * Page setup.
-         *
-         */
-        $this->_setBreadcrumb(array('text'      => $this->language->get('dashboard_breadcrumb_title'),
-                                    'href'      => $this->url->link('payment/omise/dashboard', 'token=' . $this->session->data['token'], 'SSL'),             
-                                    'separator' => ' :: '));
-
-        $this->_getSessionFlash();
-
-        $this->document->addScript(HTTP_SERVER.'/view/javascript/omise/omise-opencart-admin.js');
-
-
-        /**
-         * Template setup.
-         *
-         */
-        // Set template.
-        $this->template = 'payment/omise_dashboard.tpl';
-
-        // Include sub-template.
-        $this->children = array('common/header',
-                                'common/footer');
-
-        // Render output.
-        $this->response->setOutput($this->render());
-    }
-
-    /**
-     * Render Omise Payment Gateway extension setting page
-     * @return void
-     */
-    public function index()
-    {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        // Load model.
-        $this->load->model('setting/setting');
-        $this->load->model('payment/omise');
-
-        // Load language.
-        $this->language->load('payment/omise');
-
-
-        /**
-         * POST Request handle.
-         *
-         */
-        if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
-            $this->model_setting_setting->editSetting('omise', $this->request->post);
-
-            if (isset($this->request->post['Omise'])) {
-                $update                 = $this->request->post['Omise'];
-                $update['test_mode']    = isset($update['test_mode']) ? 1 : 0;
-
-                $this->model_payment_omise->updateConfig($update);
-
-                foreach ($update as $key => $value)
-                    $this->data[$key] = $value;
-
-                // Set error.
-                $this->data['input_error']          = array();
-            }
-
-            $this->session->data['success'] = $this->language->get('text_session_save');
-            $this->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
-        }
-
-
-        /**
-         * Language setup.
-         *
-         */
-        $this->document->setTitle('Omise Payment Gateway Configuration');
-
-        // Set form label with language.
-        $this->data['heading_title']                    = $this->language->get('heading_title');
-        $this->data['button_save']                      = $this->language->get('text_button_save');
-        $this->data['button_cancel']                    = $this->language->get('text_button_cancel');
-        $this->data['entry_order_status']               = $this->language->get('entry_order_status');
-        $this->data['text_enabled']                     = $this->language->get('text_enabled');
-        $this->data['text_disabled']                    = $this->language->get('text_disabled');
-        $this->data['entry_status']                     = $this->language->get('entry_status');
-
-        // Set Omise setting label with language.
-        $this->data['omise_key_test_public_label']      = $this->language->get('omise_key_test_public_label');
-        $this->data['omise_key_test_secret_label']      = $this->language->get('omise_key_test_secret_label');
-        $this->data['omise_test_mode_label']            = $this->language->get('omise_test_mode_label');
-        $this->data['omise_key_public_label']           = $this->language->get('omise_key_public_label');
-        $this->data['omise_key_secret_label']           = $this->language->get('omise_key_secret_label');
-
-        // Set action button.
-        $this->data['action']                           = $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL');
-        $this->data['cancel']                           = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
-
-
-        /**
-         * Page data setup.
-         *
-         */
-        $this->data['omise_status'] = $this->config->get('omise_status');
-        $omise_config = $this->model_payment_omise->getConfig();
-        foreach ($omise_config as $key => $value)
-            $this->data[$key] = $value;
-
-
-        /**
-         * Page setup.
-         *
-         */
-        $this->_setBreadcrumb()
-             ->_getSessionFlash();
-
-        
-        /**
-         * Template setup.
-         *
-         */
-        // Set template.
-        $this->template = 'payment/omise_setting.tpl';
-
-        // Include sub-template.
-        $this->children = array('common/header',
-                                'common/footer');
-
-        // Render output.
-        $this->response->setOutput($this->render());
-    }
-
-    /**
-     * Set page breadcrumb
-     * @return self
-     */
-    private function _setBreadcrumb($current = null)
-    {
-        // Set Breadcrumbs.
-        $this->data['breadcrumbs']      = array();
-
-        $this->data['breadcrumbs'][]    = array(
-            'text'      => $this->language->get('text_home'),
-            'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => false
-        );
-
-        $this->data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('text_payment'),
-            'href'      => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => ' :: '
-        );
-
-        $this->data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('heading_title'),
-            'href'      => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),             
-            'separator' => ' :: '
-        );
-
-        if (!is_null($current)) {
-            $this->data['breadcrumbs'][] = $current;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get session flash from session variable and unset it
-     * @return self
-     */
-    private function _getSessionFlash()
-    {
-        $this->data['success'] = '';
-        if (isset($this->session->data['success'])) {
-            $this->data['success'] = $this->session->data['success'];
-
-            unset($this->session->data['success']);
-        }
-
-        $this->data['error'] = '';
-        if (isset($this->session->data['error'])) {
-            $this->data['error'] = $this->session->data['error'];
-
-            unset($this->session->data['error']);
-        }
-
-        return $this;
-    }
-
-    /**
-     * This method will fire when user click `install` button from `extension/payment` page
-     * It will call `model/payment/omise.php` file and run `install` method for installl something
-     * that necessary to use in Omise Payment Gateway module
-     * @return void
-     */
-    public function install()
-    {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        // Load model.
-        $this->load->model('payment/omise');
-
-        // Load language.
-        $this->language->load('payment/omise');
-
-        try {
-            // Create new table for contain Omise Keys.
-            if (!$this->model_payment_omise->install())
-                throw new Exception($this->language->get('error_omise_table_install_failed'), 1);
-                
-            // If done. Next, install vQmod library.
-            // So, if it had vQmod in OpenCart project already,
-            // just copy omise.xml into vqmod/xml/ without installing again.
-            if (file_exists(DIR_APPLICATION.'../vqmod')) {
-                $file = DIR_APPLICATION.'../omise-opencart/vqmod/xml/omise.xml';
-                $dest = DIR_APPLICATION.'../vqmod/xml/';
-
-                // Check file exists and writable.
-                if (!file_exists($file))
-                    throw new Exception($this->language->get('error_omise_menu_xml_not_exists'), 1);
-
-                if (!file_exists($dest)) {
-                    mkdir($dest, 0777);
-                }
-
-                if (!is_writable($dest))
-                    throw new Exception($dest.' '.$this->language->get('error_file_not_writable'), 1);
-
-                // Make a copy.
-                if (!copy($file, $dest.'/omise.xml')) 
-                    throw new Exception($file.' '.$this->language->get('error_can_not_copy_file'), 1);
-            } else {
-                // If it had not, install it.
-                $file   = DIR_APPLICATION.'../omise-opencart/vqmod';
-                $dest   = DIR_APPLICATION.'..';
-                $backup = DIR_APPLICATION.'../omise-opencart/backup';
-
-                // Check file exists and writable.
-                if (!file_exists($file))
-                    throw new Exception($this->language->get('error_vqmod_xml_not_exists'), 1);
-
-                if (!is_writable($dest))
-                    throw new Exception($dest.' '.$this->language->get('error_file_not_writable'), 1);
-
-                // Create 
-                if (!file_exists($backup)) {
-                    if (!mkdir($backup))
-                        throw new Exception($backup.' '.$this->language->get('error_file_permission_denied'), 1);
-
-                    mkdir($backup.'/admin');
-
-                    $bak_catalog_index   = DIR_APPLICATION.'../index.php';
-                    $bak_admin_index     = DIR_APPLICATION.'../admin/index.php';
-                    // Make a copy catalog's index file.
-                    if (!copy($bak_catalog_index, $backup.'/index.php')) 
-                        throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
-
-                    if (!chmod($backup.'/index.php', 0755)) 
-                        throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
-
-                    // Make a copy admin's index file.
-                    if (!copy($bak_admin_index, $backup.'/admin/index.php')) 
-                        throw new Exception($bak_admin_index.' '.$this->language->get('error_can_not_copy_file'), 1);
-
-                    if (!chmod($backup.'/admin/index.php', 0755)) 
-                        throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
-                }
-
-                // Make a copy.
-                $this->copyRecursively($file, $dest.'/vqmod');
-
-                // Make an install.
-                include_once(DIR_APPLICATION.'../vqmod/install/omise-install.php');
-                $installing = vQmodOmiseEditionInstall();
-                if (isset($installing['error'])) {
-                    $this->rmdirRecursively(DIR_APPLICATION.'../vqmod');
-
-                    throw new Exception($installing['error'], 1);
-                }
-
-                if (!isset($installing['success'])) {
-                    $this->rmdirRecursively(DIR_APPLICATION.'../vqmod');
-                    
-                    throw new Exception('CODE [acpoL365]'.$this->language->get('error_general_error'), 1);
-                }
-            }
-
-            // Set `success` session if it completely done.
-            $this->session->data['success'] = "Installed";
-        } catch (Exception $e) {
-            // Uninstall Omise extension if it failed to install.
-            $this->load->model('setting/extension');
-            $this->load->model('setting/setting');
-
-            $this->model_setting_extension->uninstall('payment', 'omise');
-            $this->model_setting_setting->deleteSetting('omise');
-
-            $file = DIR_APPLICATION.'../vqmod/xml/omise.xml';
-            if (file_exists($file))
-                unlink($file);
-
-            $this->uninstall();
-
-            $this->session->data['error'] = $e->getMessage();
-        }
-    }
-
-    /**
-     * This method will fire when user click `Uninstall` button from `extension/payment` page
-     * Uninstall anything about Omise Payment Gateway module that installed.
-     * @return void
-     */
-    public function uninstall()
-    {
-        $file = DIR_APPLICATION.'../vqmod/xml/omise.xml';
-        if (file_exists($file))
-            unlink($file);
-
-        $this->load->model('payment/omise');
-        $this->model_payment_omise->uninstall();;
-    }
-
-    /**
-     * Submit a `transfer` request to Omise server
-     * @return void
-     */
-    public function submitTransfer()
-    {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        $this->load->helper('omise_currency');
-
-        // Load model.
-        $this->load->model('payment/omise');
-
-        // Load language.
-        $this->language->load('payment/omise');
-
-        try {
-            // POST request handler.
-            if (!$this->request->server['REQUEST_METHOD'] == 'POST')
-                throw new Exception($this->language->get('error_needed_post_request'), 1);
-
-            if (!isset($this->request->post['OmiseTransfer']['amount']))
-                throw new Exception($this->language->get('error_need_amount_value'), 1);
-
-            // Retrieve Omise Balance.
-            $balance      = $this->model_payment_omise->getOmiseBalance();
-            $transferring = $this->model_payment_omise->createOmiseTransfer(formatChargeAmount($balance['currency'], $this->request->post['OmiseTransfer']['amount']));
-            if (isset($transferring['error']))
-                throw new Exception('Omise Transfer:: '.$transferring['error'], 1);
-            else
-                $this->session->data['success'] = $this->language->get('api_transfer_success');
-        } catch (Exception $e) {
-            $this->session->data['error'] = $e->getMessage();
-        }
-        
-        $this->redirect($this->url->link('payment/omise/dashboard', 'token=' . $this->session->data['token'], 'SSL'));
-    }
-
-    /**
-     * This's a snippet code for recursively copy files
-     * from one directory to another (used in `install` method only).
-     * @param String $src       Source of files being moved
-     * @param String $dest      Destination of files being moved
-     * @return boolean|void
-     */
-    public function copyRecursively($src, $dest)
-    {
-        // If the destination directory does not exist create it
-        if(!is_dir($dest)) { 
-            if(!mkdir($dest)) {
-                // If the destination directory could not be created stop processing
-                return false;
-            }    
-        }
-
-        // Open the source directory to read in files
-        $i = new DirectoryIterator($src);
-        foreach($i as $f) {
-            if($f->isFile()) {
-                copy($f->getRealPath(), "$dest/" . $f->getFilename());
-            } else if(!$f->isDot() && $f->isDir()) {
-                $this->copyRecursively($f->getRealPath(), "$dest/$f");
-            }
-        }
-    }
-
-    /**
-     * This's a snippet code for recursively remove files (used in `install` method only).
-     * @param String $dir  Directory that you need to remove
-     * @return void|boolean
-     */
-    public function rmdirRecursively($dir)
-    {
-        try {
-            if (is_dir($dir)) { 
-                $objects = scandir($dir); 
-                foreach ($objects as $object) { 
-                    if ($object != "." && $object != "..") { 
-                        if (filetype($dir."/".$object) == "dir") $this->rmdirRecursively($dir."/".$object); else unlink($dir."/".$object); 
-                    } 
-                } 
-                reset($objects); 
-                rmdir($dir); 
-            }    
-        } catch (Exception $e) {
-            return false;            
-        }
-     }
+class ControllerPaymentOmise extends Controller {
+
+	/**
+	 * $error
+	 *
+	 */
+	private $error = array();
+
+	/**
+	 * Render Omise Payment Gateway dashboard page
+	 * @return void
+	 */
+	public function dashboard() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		$this->load->helper('omise_currency');
+
+		// Load model.
+		$this->load->model('payment/omise');
+
+		// Load language.
+		$this->language->load('payment/omise');
+
+		/**
+		 * Language setup.
+		 *
+		 */
+		$this->document->setTitle($this->language->get('dashboard_page_title'));
+
+		// Set page's component label with language.
+		$this->data['heading_title']            = $this->language->get('dashboard_heading_title');
+		$this->data['setting_url']              = $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL');
+		$this->data['setting_button_title']     = $this->language->get('text_button_setting');
+		$this->data['transfer_url']             = $this->url->link('payment/omise/submittransfer', 'token=' . $this->session->data['token'], 'SSL');
+
+		/**
+		 * Page data setup.
+		 *
+		 */
+		$this->data['omise'] = array();
+
+		// Check Omise extension is enabled.
+		if (!$this->config->get('omise_status')) {
+			$this->session->data['error'] = $this->language->get('error_extension_disabled');
+		} else {
+			try {
+				// Retrieve Omise Account.
+				$omise_account = $this->model_payment_omise->getOmiseAccount();
+				if (isset($omise_account['error']))
+					throw new Exception('Omise Account:: '.$omise_account['error'], 1);
+
+				$this->data['omise']['account']['email']    = $omise_account['email'];
+				$this->data['omise']['account']['created']  = $omise_account['created'];
+
+				// Retrieve Omise Balance.
+				$omise_balance = $this->model_payment_omise->getOmiseBalance();
+				if (isset($omise_balance['error']))
+					throw new Exception('Omise Balance:: '.$omise_balance['error'], 1);
+
+				$this->data['omise']['balance']['livemode']     = $omise_balance['livemode'];
+				$this->data['omise']['balance']['available']    = $omise_balance['available'];
+				$this->data['omise']['balance']['total']        = $omise_balance['total'];
+				$this->data['omise']['balance']['currency']     = $omise_balance['currency'];
+
+				// Retrieve Omise Transfer List.
+				$omise_transfer = $this->model_payment_omise->getOmiseTransferList();
+				if (isset($omise_transfer['error']))
+					throw new Exception('Omise Transfer:: '.$omise_transfer['error'], 1);
+
+				$this->data['omise']['transfer']['data']        = array_reverse($omise_transfer['data']);
+				$this->data['omise']['transfer']['total']       = $omise_transfer['total'];
+			} catch (Exception $e) {
+				$this->session->data['error'] = $e->getMessage();
+			}
+		}
+
+		/**
+		 * Page setup.
+		 *
+		 */
+		$this->_setBreadcrumb(array('text'      => $this->language->get('dashboard_breadcrumb_title'),
+									'href'      => $this->url->link('payment/omise/dashboard', 'token=' . $this->session->data['token'], 'SSL'),
+									'separator' => ' :: '));
+
+		$this->_getSessionFlash();
+
+		$this->document->addScript(HTTP_SERVER.'/view/javascript/omise/omise-opencart-admin.js');
+
+		/**
+		 * Template setup.
+		 *
+		 */
+		// Set template.
+		$this->template = 'payment/omise_dashboard.tpl';
+
+		// Include sub-template.
+		$this->children = array('common/header',
+								'common/footer');
+
+		// Render output.
+		$this->response->setOutput($this->render());
+	}
+
+	/**
+	 * Render Omise Payment Gateway extension setting page
+	 * @return void
+	 */
+	public function index() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		// Load model.
+		$this->load->model('setting/setting');
+		$this->load->model('payment/omise');
+
+		// Load language.
+		$this->language->load('payment/omise');
+
+		/**
+		 * POST Request handle.
+		 *
+		 */
+		if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
+			$this->model_setting_setting->editSetting('omise', $this->request->post);
+
+			if (isset($this->request->post['Omise'])) {
+				$update                 = $this->request->post['Omise'];
+				$update['test_mode']    = isset($update['test_mode']) ? 1 : 0;
+
+				$this->model_payment_omise->updateConfig($update);
+
+				foreach ($update as $key => $value)
+					$this->data[$key] = $value;
+
+				// Set error.
+				$this->data['input_error']          = array();
+			}
+
+			$this->session->data['success'] = $this->language->get('text_session_save');
+			$this->redirect($this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'));
+		}
+
+		/**
+		 * Language setup.
+		 *
+		 */
+		$this->document->setTitle('Omise Payment Gateway Configuration');
+
+		// Set form label with language.
+		$this->data['heading_title']                    = $this->language->get('heading_title');
+		$this->data['button_save']                      = $this->language->get('text_button_save');
+		$this->data['button_cancel']                    = $this->language->get('text_button_cancel');
+		$this->data['entry_order_status']               = $this->language->get('entry_order_status');
+		$this->data['text_enabled']                     = $this->language->get('text_enabled');
+		$this->data['text_disabled']                    = $this->language->get('text_disabled');
+		$this->data['entry_status']                     = $this->language->get('entry_status');
+
+		// Set Omise setting label with language.
+		$this->data['omise_key_test_public_label']      = $this->language->get('omise_key_test_public_label');
+		$this->data['omise_key_test_secret_label']      = $this->language->get('omise_key_test_secret_label');
+		$this->data['omise_test_mode_label']            = $this->language->get('omise_test_mode_label');
+		$this->data['omise_key_public_label']           = $this->language->get('omise_key_public_label');
+		$this->data['omise_key_secret_label']           = $this->language->get('omise_key_secret_label');
+
+		// Set action button.
+		$this->data['action']                           = $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL');
+		$this->data['cancel']                           = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
+
+		/**
+		 * Page data setup.
+		 *
+		 */
+		$this->data['omise_status'] = $this->config->get('omise_status');
+		$omise_config = $this->model_payment_omise->getConfig();
+		foreach ($omise_config as $key => $value)
+			$this->data[$key] = $value;
+
+		/**
+		 * Page setup.
+		 *
+		 */
+		$this->_setBreadcrumb()
+			 ->_getSessionFlash();
+
+		/**
+		 * Template setup.
+		 *
+		 */
+		// Set template.
+		$this->template = 'payment/omise_setting.tpl';
+
+		// Include sub-template.
+		$this->children = array('common/header',
+								'common/footer');
+
+		// Render output.
+		$this->response->setOutput($this->render());
+	}
+
+	/**
+	 * Set page breadcrumb
+	 * @return self
+	 */
+	private function _setBreadcrumb($current = null) {
+		// Set Breadcrumbs.
+		$this->data['breadcrumbs']      = array();
+
+		$this->data['breadcrumbs'][]    = array(
+			'text'      => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('text_payment'),
+			'href'      => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => ' :: '
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('heading_title'),
+			'href'      => $this->url->link('payment/omise', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => ' :: '
+		);
+
+		if (!is_null($current)) {
+			$this->data['breadcrumbs'][] = $current;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Get session flash from session variable and unset it
+	 * @return self
+	 */
+	private function _getSessionFlash() {
+		$this->data['success'] = '';
+		if (isset($this->session->data['success'])) {
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		}
+
+		$this->data['error'] = '';
+		if (isset($this->session->data['error'])) {
+			$this->data['error'] = $this->session->data['error'];
+
+			unset($this->session->data['error']);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * This method will fire when user click `install` button from `extension/payment` page
+	 * It will call `model/payment/omise.php` file and run `install` method for installl something
+	 * that necessary to use in Omise Payment Gateway module
+	 * @return void
+	 */
+	public function install() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		// Load model.
+		$this->load->model('payment/omise');
+
+		// Load language.
+		$this->language->load('payment/omise');
+
+		try {
+			// Create new table for contain Omise Keys.
+			if (!$this->model_payment_omise->install())
+				throw new Exception($this->language->get('error_omise_table_install_failed'), 1);
+
+			// If done. Next, install vQmod library.
+			// So, if it had vQmod in OpenCart project already,
+			// just copy omise.xml into vqmod/xml/ without installing again.
+			if (file_exists(DIR_APPLICATION.'../vqmod')) {
+				$file = DIR_APPLICATION.'../omise-opencart/vqmod/xml/omise.xml';
+				$dest = DIR_APPLICATION.'../vqmod/xml/';
+
+				// Check file exists and writable.
+				if (!file_exists($file))
+					throw new Exception($this->language->get('error_omise_menu_xml_not_exists'), 1);
+
+				if (!file_exists($dest)) {
+					mkdir($dest, 0777);
+				}
+
+				if (!is_writable($dest))
+					throw new Exception($dest.' '.$this->language->get('error_file_not_writable'), 1);
+
+				// Make a copy.
+				if (!copy($file, $dest.'/omise.xml'))
+					throw new Exception($file.' '.$this->language->get('error_can_not_copy_file'), 1);
+			} else {
+				// If it had not, install it.
+				$file   = DIR_APPLICATION.'../omise-opencart/vqmod';
+				$dest   = DIR_APPLICATION.'..';
+				$backup = DIR_APPLICATION.'../omise-opencart/backup';
+
+				// Check file exists and writable.
+				if (!file_exists($file))
+					throw new Exception($this->language->get('error_vqmod_xml_not_exists'), 1);
+
+				if (!is_writable($dest))
+					throw new Exception($dest.' '.$this->language->get('error_file_not_writable'), 1);
+
+				// Create
+				if (!file_exists($backup)) {
+					if (!mkdir($backup))
+						throw new Exception($backup.' '.$this->language->get('error_file_permission_denied'), 1);
+
+					mkdir($backup.'/admin');
+
+					$bak_catalog_index   = DIR_APPLICATION.'../index.php';
+					$bak_admin_index     = DIR_APPLICATION.'../admin/index.php';
+					// Make a copy catalog's index file.
+					if (!copy($bak_catalog_index, $backup.'/index.php'))
+						throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
+
+					if (!chmod($backup.'/index.php', 0755))
+						throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
+
+					// Make a copy admin's index file.
+					if (!copy($bak_admin_index, $backup.'/admin/index.php'))
+						throw new Exception($bak_admin_index.' '.$this->language->get('error_can_not_copy_file'), 1);
+
+					if (!chmod($backup.'/admin/index.php', 0755))
+						throw new Exception($bak_catalog_index.' '.$this->language->get('error_can_not_copy_file'), 1);
+				}
+
+				// Make a copy.
+				$this->copyRecursively($file, $dest.'/vqmod');
+
+				// Make an install.
+				include_once(DIR_APPLICATION.'../vqmod/install/omise-install.php');
+				$installing = vQmodOmiseEditionInstall();
+				if (isset($installing['error'])) {
+					$this->rmdirRecursively(DIR_APPLICATION.'../vqmod');
+
+					throw new Exception($installing['error'], 1);
+				}
+
+				if (!isset($installing['success'])) {
+					$this->rmdirRecursively(DIR_APPLICATION.'../vqmod');
+
+					throw new Exception('CODE [acpoL365]'.$this->language->get('error_general_error'), 1);
+				}
+			}
+
+			// Set `success` session if it completely done.
+			$this->session->data['success'] = "Installed";
+		} catch (Exception $e) {
+			// Uninstall Omise extension if it failed to install.
+			$this->load->model('setting/extension');
+			$this->load->model('setting/setting');
+
+			$this->model_setting_extension->uninstall('payment', 'omise');
+			$this->model_setting_setting->deleteSetting('omise');
+
+			$file = DIR_APPLICATION.'../vqmod/xml/omise.xml';
+			if (file_exists($file))
+				unlink($file);
+
+			$this->uninstall();
+
+			$this->session->data['error'] = $e->getMessage();
+		}
+	}
+
+	/**
+	 * This method will fire when user click `Uninstall` button from `extension/payment` page
+	 * Uninstall anything about Omise Payment Gateway module that installed.
+	 * @return void
+	 */
+	public function uninstall() {
+		$file = DIR_APPLICATION.'../vqmod/xml/omise.xml';
+		if (file_exists($file))
+			unlink($file);
+
+		$this->load->model('payment/omise');
+		$this->model_payment_omise->uninstall();;
+	}
+
+	/**
+	 * Submit a `transfer` request to Omise server
+	 * @return void
+	 */
+	public function submitTransfer() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		$this->load->helper('omise_currency');
+
+		// Load model.
+		$this->load->model('payment/omise');
+
+		// Load language.
+		$this->language->load('payment/omise');
+
+		try {
+			// POST request handler.
+			if (!$this->request->server['REQUEST_METHOD'] == 'POST')
+				throw new Exception($this->language->get('error_needed_post_request'), 1);
+
+			if (!isset($this->request->post['OmiseTransfer']['amount']))
+				throw new Exception($this->language->get('error_need_amount_value'), 1);
+
+			// Retrieve Omise Balance.
+			$balance      = $this->model_payment_omise->getOmiseBalance();
+			$transferring = $this->model_payment_omise->createOmiseTransfer(formatChargeAmount($balance['currency'], $this->request->post['OmiseTransfer']['amount']));
+			if (isset($transferring['error']))
+				throw new Exception('Omise Transfer:: '.$transferring['error'], 1);
+			else
+				$this->session->data['success'] = $this->language->get('api_transfer_success');
+		} catch (Exception $e) {
+			$this->session->data['error'] = $e->getMessage();
+		}
+
+		$this->redirect($this->url->link('payment/omise/dashboard', 'token=' . $this->session->data['token'], 'SSL'));
+	}
+
+	/**
+	 * This's a snippet code for recursively copy files
+	 * from one directory to another (used in `install` method only).
+	 * @param String $src       Source of files being moved
+	 * @param String $dest      Destination of files being moved
+	 * @return boolean|void
+	 */
+	public function copyRecursively($src, $dest) {
+		// If the destination directory does not exist create it
+		if(!is_dir($dest)) {
+			if(!mkdir($dest)) {
+				// If the destination directory could not be created stop processing
+				return false;
+			}
+		}
+
+		// Open the source directory to read in files
+		$i = new DirectoryIterator($src);
+		foreach($i as $f) {
+			if($f->isFile()) {
+				copy($f->getRealPath(), "$dest/" . $f->getFilename());
+			} else if(!$f->isDot() && $f->isDir()) {
+				$this->copyRecursively($f->getRealPath(), "$dest/$f");
+			}
+		}
+	}
+
+	/**
+	 * This's a snippet code for recursively remove files (used in `install` method only).
+	 * @param String $dir  Directory that you need to remove
+	 * @return void|boolean
+	 */
+	public function rmdirRecursively($dir) {
+		try {
+			if (is_dir($dir)) {
+				$objects = scandir($dir);
+				foreach ($objects as $object) {
+					if ($object != "." && $object != "..") {
+						if (filetype($dir."/".$object) == "dir") $this->rmdirRecursively($dir."/".$object); else unlink($dir."/".$object);
+					}
+				}
+				reset($objects);
+				rmdir($dir);
+			}
+		} catch (Exception $e) {
+			return false;
+		}
+	 }
 }

--- a/src/admin/controller/payment/omise_offsite.php
+++ b/src/admin/controller/payment/omise_offsite.php
@@ -1,161 +1,161 @@
 <?php
 
 class ControllerPaymentOmiseOffsite extends Controller {
-    /**
-     * Render Omise Payment Gateway - Internet Banking extension setting page
-     *
-     * @return void
-     */
-    public function index() {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        // Load model.
-        $this->load->model('setting/setting');
+	/**
+	 * Render Omise Payment Gateway - Internet Banking extension setting page
+	 *
+	 * @return void
+	 */
+	public function index() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		// Load model.
+		$this->load->model('setting/setting');
 
-        // Load language.
-        $this->language->load('payment/omise');
-        $this->language->load('payment/omise_offsite');
+		// Load language.
+		$this->language->load('payment/omise');
+		$this->language->load('payment/omise_offsite');
 
-        /**
-         * POST Request handle.
-         *
-         */
-        if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
-            if ($this->request->post['omise_offsite_status'] == 1 && $this->config->get('omise_status') != 1) {
-                $this->session->data['error'] = $this->language->get('error_need_omise_extension');
-                $this->data['input_error']['omise_offsite_status'] = $this->language->get('error_need_omise_extension');
-            } else {
-                $this->model_setting_setting->editSetting('omise_offsite', $this->request->post);
-                $this->data['input_error'] = array();
-                $this->data = array_merge($this->data, $this->request->post);
+		/**
+		 * POST Request handle.
+		 *
+		 */
+		if (($this->request->server['REQUEST_METHOD'] == 'POST')) {
+			if ($this->request->post['omise_offsite_status'] == 1 && $this->config->get('omise_status') != 1) {
+				$this->session->data['error'] = $this->language->get('error_need_omise_extension');
+				$this->data['input_error']['omise_offsite_status'] = $this->language->get('error_need_omise_extension');
+			} else {
+				$this->model_setting_setting->editSetting('omise_offsite', $this->request->post);
+				$this->data['input_error'] = array();
+				$this->data = array_merge($this->data, $this->request->post);
 
-                $this->session->data['success'] = $this->language->get('text_session_save');
-                $this->redirect($this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'));
-            }
-        }
+				$this->session->data['success'] = $this->language->get('text_session_save');
+				$this->redirect($this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'));
+			}
+		}
 
-        /**
-         * Language setup.
-         *
-         */
-        $this->document->setTitle('Omise Payment Gateway Internet Banking Configuration');
+		/**
+		 * Language setup.
+		 *
+		 */
+		$this->document->setTitle('Omise Payment Gateway Internet Banking Configuration');
 
-        // Set form label with language.
-        $this->data['heading_title']      = $this->language->get('heading_title');
-        $this->data['button_save']        = $this->language->get('text_button_save');
-        $this->data['button_cancel']      = $this->language->get('text_button_cancel');
-        $this->data['entry_order_status'] = $this->language->get('entry_order_status');
-        $this->data['text_enabled']       = $this->language->get('text_enabled');
-        $this->data['text_disabled']      = $this->language->get('text_disabled');
-        $this->data['entry_status']       = $this->language->get('entry_status');
+		// Set form label with language.
+		$this->data['heading_title']      = $this->language->get('heading_title');
+		$this->data['button_save']        = $this->language->get('text_button_save');
+		$this->data['button_cancel']      = $this->language->get('text_button_cancel');
+		$this->data['entry_order_status'] = $this->language->get('entry_order_status');
+		$this->data['text_enabled']       = $this->language->get('text_enabled');
+		$this->data['text_disabled']      = $this->language->get('text_disabled');
+		$this->data['entry_status']       = $this->language->get('entry_status');
 
-        // Set action button.
-        $this->data['action'] = $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL');
-        $this->data['cancel'] = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
+		// Set action button.
+		$this->data['action'] = $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL');
+		$this->data['cancel'] = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
 
-        /**
-         * Page data setup.
-         *
-         */
-        $this->data['omise_offsite_status'] = $this->config->get('omise_offsite_status');
+		/**
+		 * Page data setup.
+		 *
+		 */
+		$this->data['omise_offsite_status'] = $this->config->get('omise_offsite_status');
 
-        /**
-         * Page setup.
-         *
-         */
-        $this->_setBreadcrumb()
-             ->_getSessionFlash();
+		/**
+		 * Page setup.
+		 *
+		 */
+		$this->_setBreadcrumb()
+			 ->_getSessionFlash();
 
-        /**
-         * Template setup.
-         *
-         */
-        // Set template.
-        $this->template = 'payment/omise_offsite_setting.tpl';
+		/**
+		 * Template setup.
+		 *
+		 */
+		// Set template.
+		$this->template = 'payment/omise_offsite_setting.tpl';
 
-        // Include sub-template.
-        $this->children = array('common/header',
-                                'common/footer');
+		// Include sub-template.
+		$this->children = array('common/header',
+								'common/footer');
 
-        // Render output.
-        $this->response->setOutput($this->render());
-    }
+		// Render output.
+		$this->response->setOutput($this->render());
+	}
 
-    /**
-     * Set page breadcrumb
-     *
-     * @return self
-     */
-    private function _setBreadcrumb($current = null) {
-        // Set Breadcrumbs.
-        $this->data['breadcrumbs'] = array();
+	/**
+	 * Set page breadcrumb
+	 *
+	 * @return self
+	 */
+	private function _setBreadcrumb($current = null) {
+		// Set Breadcrumbs.
+		$this->data['breadcrumbs'] = array();
 
-        $this->data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('text_home'),
-            'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => false,
-        );
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false,
+		);
 
-        $this->data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('text_payment'),
-            'href'      => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => ' :: ',
-        );
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('text_payment'),
+			'href'      => $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => ' :: ',
+		);
 
-        $this->data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('heading_title'),
-            'href'      => $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => ' :: ',
-        );
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('heading_title'),
+			'href'      => $this->url->link('payment/omise_offsite', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => ' :: ',
+		);
 
-        if (!is_null($current)) {
-            $this->data['breadcrumbs'][] = $current;
-        }
+		if (!is_null($current)) {
+			$this->data['breadcrumbs'][] = $current;
+		}
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Get session flash from session variable and unset it
-     *
-     * @return self
-     */
-    private function _getSessionFlash() {
-        $this->data['success'] = '';
-        if (isset($this->session->data['success'])) {
-            $this->data['success'] = $this->session->data['success'];
+	/**
+	 * Get session flash from session variable and unset it
+	 *
+	 * @return self
+	 */
+	private function _getSessionFlash() {
+		$this->data['success'] = '';
+		if (isset($this->session->data['success'])) {
+			$this->data['success'] = $this->session->data['success'];
 
-            unset($this->session->data['success']);
-        }
+			unset($this->session->data['success']);
+		}
 
-        $this->data['error'] = '';
-        if (isset($this->session->data['error'])) {
-            $this->data['error'] = $this->session->data['error'];
+		$this->data['error'] = '';
+		if (isset($this->session->data['error'])) {
+			$this->data['error'] = $this->session->data['error'];
 
-            unset($this->session->data['error']);
-        }
+			unset($this->session->data['error']);
+		}
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * This method will fire when user click `install` button from `extension/payment` page
-     *
-     * @return void
-     */
-    public function install() {
-        // Set `success` session if it completely done.
-        $this->session->data['success'] = 'Installed';
-    }
+	/**
+	 * This method will fire when user click `install` button from `extension/payment` page
+	 *
+	 * @return void
+	 */
+	public function install() {
+		// Set `success` session if it completely done.
+		$this->session->data['success'] = 'Installed';
+	}
 
-    /**
-     * This method will fire when user click `Uninstall` button from `extension/payment` page
-     * Uninstall anything about Omise Payment Gateway module that installed.
-     *
-     * @return void
-     */
-    public function uninstall() {
-    }
+	/**
+	 * This method will fire when user click `Uninstall` button from `extension/payment` page
+	 * Uninstall anything about Omise Payment Gateway module that installed.
+	 *
+	 * @return void
+	 */
+	public function uninstall() {
+	}
 }

--- a/src/admin/language/english/payment/omise.php
+++ b/src/admin/language/english/payment/omise.php
@@ -46,7 +46,7 @@ $_['text_disabled']                 	= 'Disabled';
 
 
 /**
- * API Response translation 
+ * API Response translation
  *
  */
 $_['api_transfer_success']          	= 'Sent your transfer request already, please waiting for comfirmation from the bank.';

--- a/src/admin/model/payment/omise.php
+++ b/src/admin/model/payment/omise.php
@@ -1,28 +1,27 @@
 <?php
 // Define 'OMISE_USER_AGENT_SUFFIX'
 if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION'))
-    define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/'.VERSION);
+	define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/'.VERSION);
 
 // Define 'OMISE_API_VERSION'
 if(!defined('OMISE_API_VERSION'))
-    define('OMISE_API_VERSION', '2014-07-27');
+	define('OMISE_API_VERSION', '2014-07-27');
 
-class ModelPaymentOmise extends Model
-{
-    /**
-     * @var string  Omise table name
-     */
-    private $_table = 'omise_gateway';
+class ModelPaymentOmise extends Model {
 
-    /**
-     * Install a table that need to use in Omise Payment Gateway module
-     * @return boolean
-     */
-    public function install()
-    {
-        try {
-            // Create new table
-            $this->db->query("CREATE TABLE IF NOT EXISTS `".DB_PREFIX.$this->_table."` (
+	/**
+	 * @var string  Omise table name
+	 */
+	private $_table = 'omise_gateway';
+
+	/**
+	 * Install a table that need to use in Omise Payment Gateway module
+	 * @return boolean
+	 */
+	public function install() {
+		try {
+			// Create new table
+			$this->db->query("CREATE TABLE IF NOT EXISTS `".DB_PREFIX.$this->_table."` (
                 `id` int NOT NULL,
                 `public_key` varchar(45),
                 `secret_key` varchar(45),
@@ -31,9 +30,9 @@ class ModelPaymentOmise extends Model
                 `test_mode` tinyint NOT NULL DEFAULT 0,
                 PRIMARY KEY `id` (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
 
-            /* Install omise_charge table */
-            $this->db->query(
-                "CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "omise_charge` (
+			/* Install omise_charge table */
+			$this->db->query(
+				"CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "omise_charge` (
                     `id` INT(11) NOT NULL AUTO_INCREMENT,
                     `order_id` INT(11) NOT NULL,
                     `omise_charge_id` CHAR(45) NOT NULL,
@@ -41,228 +40,218 @@ class ModelPaymentOmise extends Model
                     PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
 
-            // Insert seed data into table.
-            $this->db->query("INSERT INTO `" .DB_PREFIX. "omise_gateway` 
+			// Insert seed data into table.
+			$this->db->query("INSERT INTO `" .DB_PREFIX. "omise_gateway` 
                 (`id`, `public_key`, `secret_key`, `public_key_test`, `secret_key_test`, `test_mode`)
                 VALUES (1, '', '', '', '', 0)");
 
-            return true;
-        } catch (Exception $e) {
-            return false;
-        }
-    }
+			return true;
+		} catch (Exception $e) {
+			return false;
+		}
+	}
 
-    /**
-     * Drop table when uninstall Omise Payment Gateway module
-     * @return boolean
-     */
-    public function uninstall()
-    {
-        try {
-            $this->db->query("DROP TABLE IF EXISTS `".DB_PREFIX.$this->_table."`;");
-        } catch (Exception $e) {
-            return false;
-        }
+	/**
+	 * Drop table when uninstall Omise Payment Gateway module
+	 * @return boolean
+	 */
+	public function uninstall() {
+		try {
+			$this->db->query("DROP TABLE IF EXISTS `".DB_PREFIX.$this->_table."`;");
+		} catch (Exception $e) {
+			return false;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Get config from table
-     * @return array|boolean
-     */
-    public function getConfig()
-    {
-        try {
-            return $this->db->query("SELECT * FROM `".DB_PREFIX.$this->_table."` WHERE `id` = 1")->row;
-        } catch (Exception $e) {
-            return false;            
-        }
-    }
+	/**
+	 * Get config from table
+	 * @return array|boolean
+	 */
+	public function getConfig() {
+		try {
+			return $this->db->query("SELECT * FROM `".DB_PREFIX.$this->_table."` WHERE `id` = 1")->row;
+		} catch (Exception $e) {
+			return false;
+		}
+	}
 
-    /**
-     * Update config value
-     * @return boolean
-     */
-    public function updateConfig($update)
-    {
-        try {
-            $string = "";
+	/**
+	 * Update config value
+	 * @return boolean
+	 */
+	public function updateConfig($update) {
+		try {
+			$string = "";
 
-            foreach ($update as $key => $value)
-                $string .= "`".$key."` = '".$value."', ";
+			foreach ($update as $key => $value)
+				$string .= "`".$key."` = '".$value."', ";
 
-            $string = substr($string, 0, -2);
+			$string = substr($string, 0, -2);
 
-            $this->db->query("UPDATE ".DB_PREFIX.$this->_table." SET ".$string." WHERE id = 1");
-        } catch (Exception $e) {
-            return false;            
-        }
-    }
+			$this->db->query("UPDATE ".DB_PREFIX.$this->_table." SET ".$string." WHERE id = 1");
+		} catch (Exception $e) {
+			return false;
+		}
+	}
 
-    /**
-     * Get Omise keys from table that set in Omise setting page
-     * @return array
-     */
-    private function _getOmiseKeys()
-    {
-        $omise = array();
+	/**
+	 * Get Omise keys from table that set in Omise setting page
+	 * @return array
+	 */
+	private function _getOmiseKeys() {
+		$omise = array();
 
-        if ($this->config->get('omise_status')) {
-            // Get Omise configuration.
-            $omise = $this->getConfig();
+		if ($this->config->get('omise_status')) {
+			// Get Omise configuration.
+			$omise = $this->getConfig();
 
-            // If test mode is enable,
-            // replace Omise live key with test key.
-            if ($omise['test_mode']) {
-                $omise['public_key'] = $omise['public_key_test'];
-                $omise['secret_key'] = $omise['secret_key_test'];
-            }
-        }
+			// If test mode is enable,
+			// replace Omise live key with test key.
+			if ($omise['test_mode']) {
+				$omise['public_key'] = $omise['public_key_test'];
+				$omise['secret_key'] = $omise['secret_key_test'];
+			}
+		}
 
-        return $omise;
-    }
+		return $omise;
+	}
 
-    /**
-     * Retrieve account from Omise server
-     * @return OmiseAccount|array
-     */
-    public function getOmiseAccount()
-    {
-        // Load `omise-php` library.
-        $this->load->library('omise/omise-php/lib/Omise');
+	/**
+	 * Retrieve account from Omise server
+	 * @return OmiseAccount|array
+	 */
+	public function getOmiseAccount() {
+		// Load `omise-php` library.
+		$this->load->library('omise/omise-php/lib/Omise');
 
-        // Load language.
-        $this->language->load('payment/omise');
+		// Load language.
+		$this->language->load('payment/omise');
 
-        // Get Omise Keys.
-        if ($keys = $this->_getOmiseKeys()) {
-            try {
-                $omise = OmiseAccount::retrieve($keys['public_key'], $keys['secret_key']);
+		// Get Omise Keys.
+		if ($keys = $this->_getOmiseKeys()) {
+			try {
+				$omise = OmiseAccount::retrieve($keys['public_key'], $keys['secret_key']);
 
-                return $omise;
-            } catch (Exception $e) {
-                return array('error' => $e->getMessage());
-            }
-        } else {
-            return $this->_error($this->language->get('error_extension_disabled'));
-        }
-    }
+				return $omise;
+			} catch (Exception $e) {
+				return array('error' => $e->getMessage());
+			}
+		} else {
+			return $this->_error($this->language->get('error_extension_disabled'));
+		}
+	}
 
-    /**
-     * Retrieve balance from Omise server
-     * @return OmiseBalance|array
-     */
-    public function getOmiseBalance()
-    {
-        // Load `omise-php` library.
-        $this->load->library('omise/omise-php/lib/Omise');
+	/**
+	 * Retrieve balance from Omise server
+	 * @return OmiseBalance|array
+	 */
+	public function getOmiseBalance() {
+		// Load `omise-php` library.
+		$this->load->library('omise/omise-php/lib/Omise');
 
-        // Load language.
-        $this->language->load('payment/omise');
+		// Load language.
+		$this->language->load('payment/omise');
 
-        // Get Omise Keys.
-        if ($keys = $this->_getOmiseKeys()) {
-            try {
-                $omise = OmiseBalance::retrieve($keys['public_key'], $keys['secret_key']);
+		// Get Omise Keys.
+		if ($keys = $this->_getOmiseKeys()) {
+			try {
+				$omise = OmiseBalance::retrieve($keys['public_key'], $keys['secret_key']);
 
-                return $omise;
-            } catch (Exception $e) {
-                return array('error' => $e->getMessage());
-            }
-        } else {
-            return $this->_error($this->language->get('error_extension_disabled'));
-        }
-    }
+				return $omise;
+			} catch (Exception $e) {
+				return array('error' => $e->getMessage());
+			}
+		} else {
+			return $this->_error($this->language->get('error_extension_disabled'));
+		}
+	}
 
-    /**
-     * Get transaction list from Omise server
-     * @return OmiseTransaction|array
-     */
-    public function getOmiseTransactionList()
-    {
-        // Load `omise-php` library.
-        $this->load->library('omise/omise-php/lib/Omise');
+	/**
+	 * Get transaction list from Omise server
+	 * @return OmiseTransaction|array
+	 */
+	public function getOmiseTransactionList() {
+		// Load `omise-php` library.
+		$this->load->library('omise/omise-php/lib/Omise');
 
-        // Load language.
-        $this->language->load('payment/omise');
+		// Load language.
+		$this->language->load('payment/omise');
 
-        // Get Omise Keys.
-        if ($keys = $this->_getOmiseKeys()) {
-            try {
-                $omise = OmiseTransaction::retrieve('', $keys['public_key'], $keys['secret_key']);
+		// Get Omise Keys.
+		if ($keys = $this->_getOmiseKeys()) {
+			try {
+				$omise = OmiseTransaction::retrieve('', $keys['public_key'], $keys['secret_key']);
 
-                return $omise;
-            } catch (Exception $e) {
-                return array('error' => $e->getMessage());
-            }
-        } else {
-            return $this->_error($this->language->get('error_extension_disabled'));
-        }
-    }
+				return $omise;
+			} catch (Exception $e) {
+				return array('error' => $e->getMessage());
+			}
+		} else {
+			return $this->_error($this->language->get('error_extension_disabled'));
+		}
+	}
 
-    /**
-     * Get transfer list from Omise server
-     * @return OmiseTransfer|array
-     */
-    public function getOmiseTransferList()
-    {
-        // Load `omise-php` library.
-        $this->load->library('omise/omise-php/lib/Omise');
+	/**
+	 * Get transfer list from Omise server
+	 * @return OmiseTransfer|array
+	 */
+	public function getOmiseTransferList() {
+		// Load `omise-php` library.
+		$this->load->library('omise/omise-php/lib/Omise');
 
-        // Load language.
-        $this->language->load('payment/omise');
+		// Load language.
+		$this->language->load('payment/omise');
 
-        // Get Omise Keys.
-        if ($keys = $this->_getOmiseKeys()) {
-            try {
-                $omise = OmiseTransfer::retrieve('', $keys['public_key'], $keys['secret_key']);
+		// Get Omise Keys.
+		if ($keys = $this->_getOmiseKeys()) {
+			try {
+				$omise = OmiseTransfer::retrieve('', $keys['public_key'], $keys['secret_key']);
 
-                return $omise;
-            } catch (Exception $e) {
-                return array('error' => $e->getMessage());
-            }
-        } else {
-            return $this->_error($this->language->get('error_extension_disabled'));
-        }
-    }
+				return $omise;
+			} catch (Exception $e) {
+				return array('error' => $e->getMessage());
+			}
+		} else {
+			return $this->_error($this->language->get('error_extension_disabled'));
+		}
+	}
 
-    /**
-     * Create a transfer to Omise server
-     * @return OmiseTransfer|array
-     */
-    public function createOmiseTransfer($amount)
-    {
-        // Load `omise-php` library.
-        $this->load->library('omise/omise-php/lib/Omise');
+	/**
+	 * Create a transfer to Omise server
+	 * @return OmiseTransfer|array
+	 */
+	public function createOmiseTransfer($amount) {
+		// Load `omise-php` library.
+		$this->load->library('omise/omise-php/lib/Omise');
 
-        // Load language.
-        $this->language->load('payment/omise');
-        
-        // Get Omise Keys.
-        if ($keys = $this->_getOmiseKeys()) {
-            try {
-                $omise = OmiseTransfer::create(array('amount' => $amount), $keys['public_key'], $keys['secret_key']);
+		// Load language.
+		$this->language->load('payment/omise');
 
-                if (isset($omise['object']) && $omise['object'] == "transfer")
-                    return true;
-                else
-                    return array('error' => 'Something went wrong.');
-            } catch (Exception $e) {
-                return array('error' => $e->getMessage());
-            }
-        } else {
-            return $this->_error($this->language->get('error_extension_disabled'));
-        }
-    }
+		// Get Omise Keys.
+		if ($keys = $this->_getOmiseKeys()) {
+			try {
+				$omise = OmiseTransfer::create(array('amount' => $amount), $keys['public_key'], $keys['secret_key']);
 
-    /**
-     * Return error array template
-     * @return array
-     */
-    private function _error($msg = '')
-    {
-        return array('error' => $msg);
-    }
+				if (isset($omise['object']) && $omise['object'] == "transfer")
+					return true;
+				else
+					return array('error' => 'Something went wrong.');
+			} catch (Exception $e) {
+				return array('error' => $e->getMessage());
+			}
+		} else {
+			return $this->_error($this->language->get('error_extension_disabled'));
+		}
+	}
+
+	/**
+	 * Return error array template
+	 * @return array
+	 */
+	private function _error($msg = '') {
+		return array('error' => $msg);
+	}
 }
 ?>

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -2,249 +2,249 @@
 
 // Define 'OMISE_USER_AGENT_SUFFIX'
 if (!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION')) {
-    define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/' . VERSION);
+	define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/' . VERSION);
 }
 
 // Define 'OMISE_API_VERSION'
 if (!defined('OMISE_API_VERSION')) {
-    define('OMISE_API_VERSION', '2014-07-27');
+	define('OMISE_API_VERSION', '2014-07-27');
 }
 
 class ControllerPaymentOmise extends Controller {
-    public function checkoutCallback() {
-        if ($this->request->get['order_id']) {
-            // Load `omise-php` library.
-            $this->load->library('omise/omise-php/lib/Omise');
+	public function checkoutCallback() {
+		if ($this->request->get['order_id']) {
+			// Load `omise-php` library.
+			$this->load->library('omise/omise-php/lib/Omise');
 
-            // Get Omise configuration.
-            $omise = $this->config->get('Omise');
+			// Get Omise configuration.
+			$omise = $this->config->get('Omise');
 
-            // If test mode was enabled,
-            // replace Omise live key with test key.
-            if (isset($omise['test_mode']) && $omise['test_mode']) {
-                $omise['public_key'] = $omise['public_key_test'];
-                $omise['secret_key'] = $omise['secret_key_test'];
-            }
+			// If test mode was enabled,
+			// replace Omise live key with test key.
+			if (isset($omise['test_mode']) && $omise['test_mode']) {
+				$omise['public_key'] = $omise['public_key_test'];
+				$omise['secret_key'] = $omise['secret_key_test'];
+			}
 
-            // Create a order history with `Processing` status
-            $this->load->model('checkout/order');
-            $this->load->model('payment/omise');
+			// Create a order history with `Processing` status
+			$this->load->model('checkout/order');
+			$this->load->model('payment/omise');
 
-            $order_id = $this->request->get['order_id'];
-            $transaction = $this->model_payment_omise->getChargeTransaction($order_id);
-            $omise_charge = OmiseCharge::retrieve($transaction->row['omise_charge_id'], $omise['public_key'], $omise['secret_key']);
-            if ($omise_charge && $omise_charge['authorized'] && $omise_charge['captured']) {
-                // Status: processed.
-                $this->model_checkout_order->confirm($order_id, 15);
-                $this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
-            } else {
-                // Status: failed.
-                $this->model_checkout_order->confirm($order_id, 10);
-                $this->response->redirect($this->url->link('payment/omise/failure', '', 'SSL'));
-            }
-        }
+			$order_id = $this->request->get['order_id'];
+			$transaction = $this->model_payment_omise->getChargeTransaction($order_id);
+			$omise_charge = OmiseCharge::retrieve($transaction->row['omise_charge_id'], $omise['public_key'], $omise['secret_key']);
+			if ($omise_charge && $omise_charge['authorized'] && $omise_charge['captured']) {
+				// Status: processed.
+				$this->model_checkout_order->confirm($order_id, 15);
+				$this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
+			} else {
+				// Status: failed.
+				$this->model_checkout_order->confirm($order_id, 10);
+				$this->response->redirect($this->url->link('payment/omise/failure', '', 'SSL'));
+			}
+		}
 
-        exit;
-    }
+		exit;
+	}
 
-    /**
-     * OpenCart 1 does not provide common 'checkout/failure' page, so we need to add one.
-     */
-    public function failure() {
-        $this->language->load('payment/omise');
+	/**
+	 * OpenCart 1 does not provide common 'checkout/failure' page, so we need to add one.
+	 */
+	public function failure() {
+		$this->language->load('payment/omise');
 
-        $this->document->setTitle($this->language->get('heading_title'));
+		$this->document->setTitle($this->language->get('heading_title'));
 
-        $this->data['heading_title']       = $this->language->get('heading_title');
-        $this->data['text_payment_failed'] = $this->language->get('text_payment_failed');
+		$this->data['heading_title']       = $this->language->get('heading_title');
+		$this->data['text_payment_failed'] = $this->language->get('text_payment_failed');
 
-        if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_failure.tpl')) {
-            $this->template = $this->config->get('config_template') . '/template/payment/omise_failure.tpl';
-        } else {
-            $this->template = 'default/template/payment/omise_failure.tpl';
-        }
+		if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_failure.tpl')) {
+			$this->template = $this->config->get('config_template') . '/template/payment/omise_failure.tpl';
+		} else {
+			$this->template = 'default/template/payment/omise_failure.tpl';
+		}
 
-        $this->children = array(
-            'common/column_left',
-            'common/column_right',
-            'common/content_top',
-            'common/content_bottom',
-            'common/footer',
-            'common/header'
-        );
+		$this->children = array(
+			'common/column_left',
+			'common/column_right',
+			'common/content_top',
+			'common/content_bottom',
+			'common/footer',
+			'common/header'
+		);
 
-        $this->response->setOutput($this->render(true));
-    }
+		$this->response->setOutput($this->render(true));
+	}
 
-    /**
-     * Checkout orders and charge a card process
-     *
-     * @return string(Json)
-     */
-    public function checkout() {
-        // If has a `post['omise_token']` request.
-        if (isset($this->request->post['omise_token'])) {
-            $this->load->helper('omise_currency');
+	/**
+	 * Checkout orders and charge a card process
+	 *
+	 * @return string(Json)
+	 */
+	public function checkout() {
+		// If has a `post['omise_token']` request.
+		if (isset($this->request->post['omise_token'])) {
+			$this->load->helper('omise_currency');
 
-            // Load `omise-php` library.
-            $this->load->library('omise/omise-php/lib/Omise');
+			// Load `omise-php` library.
+			$this->load->library('omise/omise-php/lib/Omise');
 
-            // Get Omise configuration.
-            $omise = $this->config->get('Omise');
+			// Get Omise configuration.
+			$omise = $this->config->get('Omise');
 
-            // If test mode was enabled,
-            // replace Omise live key with test key.
-            if (isset($omise['test_mode']) && $omise['test_mode']) {
-                $omise['public_key'] = $omise['public_key_test'];
-                $omise['secret_key'] = $omise['secret_key_test'];
-            }
+			// If test mode was enabled,
+			// replace Omise live key with test key.
+			if (isset($omise['test_mode']) && $omise['test_mode']) {
+				$omise['public_key'] = $omise['public_key_test'];
+				$omise['secret_key'] = $omise['secret_key_test'];
+			}
 
-            // Create a order history with `Processing` status
-            $this->load->model('checkout/order');
-            $order_id    = $this->session->data['order_id'];
-            $order_info  = $this->model_checkout_order->getOrder($order_id);
-            $order_total = $this->currency->format(
-                $order_info['total'],
-                $order_info['currency_code'],
-                $order_info['currency_value'],
-                false
-            );
+			// Create a order history with `Processing` status
+			$this->load->model('checkout/order');
+			$order_id    = $this->session->data['order_id'];
+			$order_info  = $this->model_checkout_order->getOrder($order_id);
+			$order_total = $this->currency->format(
+				$order_info['total'],
+				$order_info['currency_code'],
+				$order_info['currency_value'],
+				false
+			);
 
-            if ($order_info) {
-                try {
-                    // Try to create a charge and capture it.
-                    $omise_charge = OmiseCharge::create(
-                        array(
-                            'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
-                            'currency'    => $order_info['currency_code'],
-                            'description' => $this->request->post['description'],
-                            'card'        => $this->request->post['omise_token']
-                        ),
-                        $omise['public_key'],
-                        $omise['secret_key']
-                    );
+			if ($order_info) {
+				try {
+					// Try to create a charge and capture it.
+					$omise_charge = OmiseCharge::create(
+						array(
+							'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
+							'currency'    => $order_info['currency_code'],
+							'description' => $this->request->post['description'],
+							'card'        => $this->request->post['omise_token']
+						),
+						$omise['public_key'],
+						$omise['secret_key']
+					);
 
-                    if (is_null($omise_charge['failure_code']) && is_null($omise_charge['failure_code']) && $omise_charge['captured']) {
-                        // Status: processed.
-                        $this->model_checkout_order->confirm($order_id, 15);
-                    } else {
-                        // Status: failed.
-                        $this->model_checkout_order->update($order_id, 10);
-                    }
+					if (is_null($omise_charge['failure_code']) && is_null($omise_charge['failure_code']) && $omise_charge['captured']) {
+						// Status: processed.
+						$this->model_checkout_order->confirm($order_id, 15);
+					} else {
+						// Status: failed.
+						$this->model_checkout_order->update($order_id, 10);
+					}
 
-                    echo json_encode(
-                        array(
-                            'failure_code'    => $omise_charge['failure_code'],
-                            'failure_message' => $omise_charge['failure_message'],
-                            'captured'        => $omise_charge['captured'],
-                            'omise'           => $omise_charge
-                        )
-                    );
-                } catch (Exception $e) {
-                    // Status: failed.
-                    $this->model_checkout_order->update($this->session->data['order_id'], 10);
-                    echo json_encode(array('error' => $e->getMessage()));
-                }
-            } else {
-                echo json_encode(array('error' => 'Cannot find your order, please try again.'));
-            }
-        } else {
-            return 'not authorized';
-        }
-    }
+					echo json_encode(
+						array(
+							'failure_code'    => $omise_charge['failure_code'],
+							'failure_message' => $omise_charge['failure_message'],
+							'captured'        => $omise_charge['captured'],
+							'omise'           => $omise_charge
+						)
+					);
+				} catch (Exception $e) {
+					// Status: failed.
+					$this->model_checkout_order->update($this->session->data['order_id'], 10);
+					echo json_encode(array('error' => $e->getMessage()));
+				}
+			} else {
+				echo json_encode(array('error' => 'Cannot find your order, please try again.'));
+			}
+		} else {
+			return 'not authorized';
+		}
+	}
 
-    /**
-     * Retrieve list of months translation
-     *
-     * @return array
-     */
-    public function getMonths() {
-        $months = array();
-        for ($index = 1; $index <= 12; $index++) {
-            $month = ($index < 10) ? '0' . $index : $index;
-            $months[$month] = $month;
-        }
-        return $months;
-    }
+	/**
+	 * Retrieve list of months translation
+	 *
+	 * @return array
+	 */
+	public function getMonths() {
+		$months = array();
+		for ($index = 1; $index <= 12; $index++) {
+			$month = ($index < 10) ? '0' . $index : $index;
+			$months[$month] = $month;
+		}
+		return $months;
+	}
 
-    /**
-     * Retrieve array of available years
-     *
-     * @return array
-     */
-    public function getYears() {
-        $years = array();
-        $first = date('Y');
+	/**
+	 * Retrieve array of available years
+	 *
+	 * @return array
+	 */
+	public function getYears() {
+		$years = array();
+		$first = date('Y');
 
-        for ($index = 0; $index <= 10; $index++) {
-            $year = $first + $index;
-            $years[$year] = $year;
-        }
-        return $years;
-    }
+		for ($index = 0; $index <= 10; $index++) {
+			$year = $first + $index;
+			$years[$year] = $year;
+		}
+		return $years;
+	}
 
-    /**
-     * Omise card information form
-     *
-     * @return void
-     */
-    protected function index() {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        // Load language.
-        $this->language->load('payment/omise');
+	/**
+	 * Omise card information form
+	 *
+	 * @return void
+	 */
+	protected function index() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		// Load language.
+		$this->language->load('payment/omise');
 
-        // Get Omise configuration.
-        $omise = $this->config->get('Omise');
-        
-        // If test mode was enabled, replace Omise public and secret key with test key.
-        if (isset($omise['test_mode']) && $omise['test_mode']) {
-            $omise['public_key'] = $omise['public_key_test'];
-            $omise['secret_key'] = $omise['secret_key_test'];
-        }
+		// Get Omise configuration.
+		$omise = $this->config->get('Omise');
 
-        $this->data['button_confirm'] = $this->language->get('button_confirm');
-        $this->data['checkout_url']   = $this->url->link('payment/omise/checkout', '', 'SSL');
-        $this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
+		// If test mode was enabled, replace Omise public and secret key with test key.
+		if (isset($omise['test_mode']) && $omise['test_mode']) {
+			$omise['public_key'] = $omise['public_key_test'];
+			$omise['secret_key'] = $omise['secret_key_test'];
+		}
 
-        $this->load->model('checkout/order');
-        $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
+		$this->data['button_confirm'] = $this->language->get('button_confirm');
+		$this->data['checkout_url']   = $this->url->link('payment/omise/checkout', '', 'SSL');
+		$this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
 
-        if ($order_info) {
-            $this->data['text_config_one']  = trim($this->config->get('text_config_one'));
-            $this->data['text_config_two']  = trim($this->config->get('text_config_two'));
-            $this->data['orderid']          = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
-            $this->data['orderdate']        = date('YmdHis');
-            $this->data['currency']         = $order_info['currency_code'];
-            $this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'] , false, false);
-            $this->data['billemail']        = $order_info['email'];
-            $this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
-            $this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryemail']    = $order_info['email'];
-            $this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+		$this->load->model('checkout/order');
+		$order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
 
-            $this->data['omise']            = $omise;
+		if ($order_info) {
+			$this->data['text_config_one']  = trim($this->config->get('text_config_one'));
+			$this->data['text_config_two']  = trim($this->config->get('text_config_two'));
+			$this->data['orderid']          = date('His') . $this->session->data['order_id'];
+			$this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
+			$this->data['orderdate']        = date('YmdHis');
+			$this->data['currency']         = $order_info['currency_code'];
+			$this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
+			$this->data['billemail']        = $order_info['email'];
+			$this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+			$this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+			$this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
+			$this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
+			$this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+			$this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryemail']    = $order_info['email'];
+			$this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
 
-            if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise.tpl')) {
-                $this->template = $this->config->get('config_template') . '/template/payment/omise.tpl';
-            } else {
-                $this->template = 'default/template/payment/omise.tpl';
-            }
+			$this->data['omise']            = $omise;
 
-            $this->render();
-        }
-    }
+			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise.tpl')) {
+				$this->template = $this->config->get('config_template') . '/template/payment/omise.tpl';
+			} else {
+				$this->template = 'default/template/payment/omise.tpl';
+			}
+
+			$this->render();
+		}
+	}
 }

--- a/src/catalog/controller/payment/omise_offsite.php
+++ b/src/catalog/controller/payment/omise_offsite.php
@@ -1,150 +1,150 @@
 <?php
 
 class ControllerPaymentOmiseOffsite extends Controller {
-    /**
-     * Checkout orders and charge a card process
-     *
-     * @return string(Json)
-     */
-    public function checkout() {
-        // Define 'OMISE_USER_AGENT_SUFFIX'
-        if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION')) {
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/' . VERSION);
-        }
+	/**
+	 * Checkout orders and charge a card process
+	 *
+	 * @return string(Json)
+	 */
+	public function checkout() {
+		// Define 'OMISE_USER_AGENT_SUFFIX'
+		if(!defined('OMISE_USER_AGENT_SUFFIX') && defined('VERSION')) {
+			define('OMISE_USER_AGENT_SUFFIX', 'OmiseOpenCart/1.4 OpenCart/' . VERSION);
+		}
 
-        // Define 'OMISE_API_VERSION'
-        if(!defined('OMISE_API_VERSION')) {
-            define('OMISE_API_VERSION', '2014-07-27');
-        }
+		// Define 'OMISE_API_VERSION'
+		if(!defined('OMISE_API_VERSION')) {
+			define('OMISE_API_VERSION', '2014-07-27');
+		}
 
-        // If has a `post['omise_token']` request.
-        if (!empty($this->request->post['offsite_provider'])) {
-            $this->load->helper('omise_currency');
+		// If has a `post['omise_token']` request.
+		if (!empty($this->request->post['offsite_provider'])) {
+			$this->load->helper('omise_currency');
 
-            // Load `omise-php` library.
-            $this->load->library('omise/omise-php/lib/Omise');
+			// Load `omise-php` library.
+			$this->load->library('omise/omise-php/lib/Omise');
 
-            // Get Omise configuration.
-            $omise = $this->config->get('Omise');
+			// Get Omise configuration.
+			$omise = $this->config->get('Omise');
 
-            // If test mode was enabled,
-            // replace Omise live key with test key.
-            if (isset($omise['test_mode']) && $omise['test_mode']) {
-                $omise['public_key'] = $omise['public_key_test'];
-                $omise['secret_key'] = $omise['secret_key_test'];
-            }
+			// If test mode was enabled,
+			// replace Omise live key with test key.
+			if (isset($omise['test_mode']) && $omise['test_mode']) {
+				$omise['public_key'] = $omise['public_key_test'];
+				$omise['secret_key'] = $omise['secret_key_test'];
+			}
 
-            // Create a order history with `Processing` status
-            $this->load->model('checkout/order');
-            $this->load->model('payment/omise');
+			// Create a order history with `Processing` status
+			$this->load->model('checkout/order');
+			$this->load->model('payment/omise');
 
-            $order_id    = $this->session->data['order_id'];
-            $order_info  = $this->model_checkout_order->getOrder($order_id);
-            $order_total = $this->currency->format(
-                $order_info['total'],
-                $order_info['currency_code'],
-                $order_info['currency_value'],
-                false
-            );
+			$order_id    = $this->session->data['order_id'];
+			$order_info  = $this->model_checkout_order->getOrder($order_id);
+			$order_total = $this->currency->format(
+				$order_info['total'],
+				$order_info['currency_code'],
+				$order_info['currency_value'],
+				false
+			);
 
-            if ($order_info) {
-                try {
-                    // Try to create a charge and capture it.
-                    $omise_charge = OmiseCharge::create(
-                        array(
-                            'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
-                            'currency'    => $order_info['currency_code'],
-                            'description' => $this->request->post['description'],
-                            'return_uri'  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
-                            'offsite'     => $this->request->post['offsite_provider']
-                        ),
-                        $omise['public_key'],
-                        $omise['secret_key']
-                    );
+			if ($order_info) {
+				try {
+					// Try to create a charge and capture it.
+					$omise_charge = OmiseCharge::create(
+						array(
+							'amount'      => formatChargeAmount($order_info['currency_code'], $order_total),
+							'currency'    => $order_info['currency_code'],
+							'description' => $this->request->post['description'],
+							'return_uri'  => $this->url->link('payment/omise/checkoutcallback&order_id='.$order_id, '', 'SSL'),
+							'offsite'     => $this->request->post['offsite_provider']
+						),
+						$omise['public_key'],
+						$omise['secret_key']
+					);
 
-                    if (is_null($omise_charge['failure_code']) && is_null($omise_charge['failure_code'])) {
-                        // Status: processing.
-                        $this->model_payment_omise->addChargeTransaction($order_id, $omise_charge['id']);
-                        $this->model_checkout_order->update($order_id, 2);
-                    } else {
-                        // Status: failed.
-                        $this->model_checkout_order->update($order_id, 10);
-                    }
+					if (is_null($omise_charge['failure_code']) && is_null($omise_charge['failure_code'])) {
+						// Status: processing.
+						$this->model_payment_omise->addChargeTransaction($order_id, $omise_charge['id']);
+						$this->model_checkout_order->update($order_id, 2);
+					} else {
+						// Status: failed.
+						$this->model_checkout_order->update($order_id, 10);
+					}
 
-                    echo json_encode(
-                        array(
-                            'failure_code'    => $omise_charge['failure_code'],
-                            'failure_message' => $omise_charge['failure_message'],
-                            'captured'        => $omise_charge['captured'],
-                            'omise'           => $omise_charge,
-                            'redirect'        => $omise_charge['authorize_uri']
-                        )
-                    );
-                } catch (Exception $e) {
-                    // Status: failed.
-                    $this->model_checkout_order->update($this->session->data['order_id'], 10);
-                    echo json_encode(array('error' => $e->getMessage()));
-                }
-            } else {
-                echo json_encode(array('error' => 'Cannot find your order, please try again.'));
-            }
-        } else {
-            echo json_encode(array('error' => 'Please select one provider from the list.'));
-        }
-    }
-    
-    /**
-     * Omise card information form
-     *
-     * @return void
-     */
-    protected function index() {
-        /**
-         * Prepare and loading necessary scripts.
-         *
-         */
-        // Load language.
-        $this->language->load('payment/omise');
-        $this->language->load('payment/omise_offsite');
+					echo json_encode(
+						array(
+							'failure_code'    => $omise_charge['failure_code'],
+							'failure_message' => $omise_charge['failure_message'],
+							'captured'        => $omise_charge['captured'],
+							'omise'           => $omise_charge,
+							'redirect'        => $omise_charge['authorize_uri']
+						)
+					);
+				} catch (Exception $e) {
+					// Status: failed.
+					$this->model_checkout_order->update($this->session->data['order_id'], 10);
+					echo json_encode(array('error' => $e->getMessage()));
+				}
+			} else {
+				echo json_encode(array('error' => 'Cannot find your order, please try again.'));
+			}
+		} else {
+			echo json_encode(array('error' => 'Please select one provider from the list.'));
+		}
+	}
 
-        $this->data['button_confirm'] = $this->language->get('button_confirm');
-        $this->data['checkout_url']   = $this->url->link('payment/omise_offsite/checkout', '', 'SSL');
-        $this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
+	/**
+	 * Omise card information form
+	 *
+	 * @return void
+	 */
+	protected function index() {
+		/**
+		 * Prepare and loading necessary scripts.
+		 *
+		 */
+		// Load language.
+		$this->language->load('payment/omise');
+		$this->language->load('payment/omise_offsite');
 
-        $this->load->model('checkout/order');
-        $order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
+		$this->data['button_confirm'] = $this->language->get('button_confirm');
+		$this->data['checkout_url']   = $this->url->link('payment/omise_offsite/checkout', '', 'SSL');
+		$this->data['success_url']    = $this->url->link('checkout/success', '', 'SSL');
 
-        if ($order_info) {
-            $this->data['text_config_one']  = trim($this->config->get('text_config_one'));
-            $this->data['text_config_two']  = trim($this->config->get('text_config_two'));
-            $this->data['orderid']          = date('His') . $this->session->data['order_id'];
-            $this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
-            $this->data['orderdate']        = date('YmdHis');
-            $this->data['currency']         = $order_info['currency_code'];
-            $this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
-            $this->data['billemail']        = $order_info['email'];
-            $this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
-            $this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliveryemail']    = $order_info['email'];
-            $this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
-            $this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
+		$this->load->model('checkout/order');
+		$order_info = $this->model_checkout_order->getOrder($this->session->data['order_id']);
 
-            if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_offsite.tpl')) {
-                $this->template = $this->config->get('config_template') . '/template/payment/omise_offsite.tpl';
-            } else {
-                $this->template = 'default/template/payment/omise_offsite.tpl';
-            }
+		if ($order_info) {
+			$this->data['text_config_one']  = trim($this->config->get('text_config_one'));
+			$this->data['text_config_two']  = trim($this->config->get('text_config_two'));
+			$this->data['orderid']          = date('His') . $this->session->data['order_id'];
+			$this->data['callbackurl']      = $this->url->link('payment/custom/callback', '', 'SSL');
+			$this->data['orderdate']        = date('YmdHis');
+			$this->data['currency']         = $order_info['currency_code'];
+			$this->data['orderamount']      = $this->currency->format($order_info['total'], $this->data['currency'], false, false);
+			$this->data['billemail']        = $order_info['email'];
+			$this->data['billphone']        = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+			$this->data['billaddress']      = html_entity_decode($order_info['payment_address_1'], ENT_QUOTES, 'UTF-8');
+			$this->data['billcountry']      = html_entity_decode($order_info['payment_iso_code_2'], ENT_QUOTES, 'UTF-8');
+			$this->data['billprovince']     = html_entity_decode($order_info['payment_zone'], ENT_QUOTES, 'UTF-8');;
+			$this->data['billcity']         = html_entity_decode($order_info['payment_city'], ENT_QUOTES, 'UTF-8');
+			$this->data['billpost']         = html_entity_decode($order_info['payment_postcode'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryname']     = html_entity_decode($order_info['shipping_firstname'] . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryaddress']  = html_entity_decode($order_info['shipping_address_1'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverycity']     = html_entity_decode($order_info['shipping_city'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverycountry']  = html_entity_decode($order_info['shipping_iso_code_2'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryprovince'] = html_entity_decode($order_info['shipping_zone'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliveryemail']    = $order_info['email'];
+			$this->data['deliveryphone']    = html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8');
+			$this->data['deliverypost']     = html_entity_decode($order_info['shipping_postcode'], ENT_QUOTES, 'UTF-8');
 
-            $this->render();
-        }
-    }
+			if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_offsite.tpl')) {
+				$this->template = $this->config->get('config_template') . '/template/payment/omise_offsite.tpl';
+			} else {
+				$this->template = 'default/template/payment/omise_offsite.tpl';
+			}
+
+			$this->render();
+		}
+	}
 }

--- a/src/catalog/model/payment/omise.php
+++ b/src/catalog/model/payment/omise.php
@@ -1,29 +1,30 @@
 <?php
 
-class ModelPaymentOmise extends Model
-{
-    public function getMethod($address, $total) {
-        $this->load->language('payment/omise');
-     
-        $method_data = array(   'code'          => 'omise',
-                                'title'         => $this->language->get('text_title'),
-                                'sort_order'    => $this->config->get('custom_sort_order'));
-     
-       return $method_data;
-     }    
+class ModelPaymentOmise extends Model {
 
-     public function addChargeTransaction($order_id, $charge_id) {
-         $this->db->query(
-             "INSERT INTO `" . DB_PREFIX . "omise_charge` " .
-             "SET order_id = '" . $this->db->escape($order_id) . "', " . 
-             "omise_charge_id = '" . $this->db->escape($charge_id) . "', " .
-             "date_added = NOW()");
-     }
+	public function getMethod($address, $total) {
+		$this->load->language('payment/omise');
 
-     public function getChargeTransaction($order_id) {
-         return $this->db->query(
-             "SELECT * " .
-             "FROM `" . DB_PREFIX . "omise_charge` " .
-             "WHERE order_id = '" . $this->db->escape($order_id) . "'");
-     }
+		$method_data = array(
+			'code'       => 'omise',
+			'title'      => $this->language->get('text_title'),
+			'sort_order' => $this->config->get('custom_sort_order'));
+
+	   return $method_data;
+	 }
+
+	 public function addChargeTransaction($order_id, $charge_id) {
+		 $this->db->query(
+			 "INSERT INTO `" . DB_PREFIX . "omise_charge` " .
+			 "SET order_id = '" . $this->db->escape($order_id) . "', " .
+			 "omise_charge_id = '" . $this->db->escape($charge_id) . "', " .
+			 "date_added = NOW()");
+	 }
+
+	 public function getChargeTransaction($order_id) {
+		 return $this->db->query(
+			 "SELECT * " .
+			 "FROM `" . DB_PREFIX . "omise_charge` " .
+			 "WHERE order_id = '" . $this->db->escape($order_id) . "'");
+	 }
 }

--- a/src/catalog/model/payment/omise_offsite.php
+++ b/src/catalog/model/payment/omise_offsite.php
@@ -1,24 +1,24 @@
 <?php
 
 class ModelPaymentOmiseOffsite extends Model {
-    public function getMethod($address, $total) {
-        if ($this->config->get('omise_status') != 1) {
-            return false;
-        }
+	public function getMethod($address, $total) {
+		if ($this->config->get('omise_status') != 1) {
+			return false;
+		}
 
-        $this->load->language('payment/omise_offsite');
+		$this->load->language('payment/omise_offsite');
 
-        if ($this->config->get('omise_offsite_payment_title') != '') {
-            $payment_title = $this->config->get('omise_offsite_payment_title');
-        } else {
-            $payment_title = $this->language->get('text_title');
-        }
+		if ($this->config->get('omise_offsite_payment_title') != '') {
+			$payment_title = $this->config->get('omise_offsite_payment_title');
+		} else {
+			$payment_title = $this->language->get('text_title');
+		}
 
-        return array(
-            'code'       => 'omise_offsite',
-            'title'      => $payment_title,
-            'terms'      => '',
-            'sort_order' => $this->config->get('omise_offsite_sort_order')
-        );
-    }
+		return array(
+			'code'       => 'omise_offsite',
+			'title'      => $payment_title,
+			'terms'      => '',
+			'sort_order' => $this->config->get('omise_offsite_sort_order')
+		);
+	}
 }


### PR DESCRIPTION
#### 1. Objective

This PR reformats all PHP files according to OpenCart provided [ruleset.xml](https://github.com/opencart/opencart/blob/master/tests/phpcs/OpenCart/ruleset.xml).

#### 2. Description of change

- add a PHP_CodeSniffer configuration file, `phpcs.xml`
- add a PHP_CodeSniffer ruleset file, `.phpcs/OpenCart/ruleset.xml`
  - add 2 additional rules to the ruleset file for formatting the opening curly braces of class and function
- format the PHP files under the directories, `src/admin` and `src/catalog`, by using the tool PHP Code Beautifier and Fixer (phpcbf)

The commands below are the commands used to automatically format the PHP files.
```
$ composer global require "squizlabs/php_codesniffer=*"
$ phpcbf src/admin
$ phpcbf src/catalog
```

The command below is the command used to check the coding standard.
```
$ phpcs src/
```

Note:
By default, the command `phpcs` automatically read the configuration file that has been named `phpcs.xml`. So, to run the above command `phpcs`, it is not need to specify the configuration file.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 1.5.6.4
- **Omise plugin version**: Omise-OpenCart 1.4
- **PHP versions**: 5.3.29 and 5.5.9

**✏️ Details:**

Test everything.

Test case 1: Create success charge by credit card
Test case 2: Create fail charge by credit card
Test case 3: Create success charge by internet banking
Test case 4: Create fail charge by internet banking

#### 4. Impact of the change

The PHP files under directories, `src/admin` and `src/catalog` are reformatted by using ruleset from the OpenCart Coding standards.

#### 5. Priority of change

High, or conflict.

#### 6. Additional notes

- The reason for adding 2 files, configuration file (`phpcs.xml`) and ruleset file (`.phpcs/OpenCart/ruleset.xml`) is to separate the rule out from the configuration. So, the ruleset file will contained only rules for checking the PHP source code.

- The reason for adding additional 2 rules to the ruleset file is from the [OpenCart Coding standards page](https://github.com/opencart/opencart/wiki/Coding-standards), it has specified a [new line standard](https://github.com/opencart/opencart/wiki/Coding-standards#new-lines) but in the OpenCart ruleset file, it has not specify this rule.
So, it need to add more rules to make the ruleset file conformed with the rule on the OpenCart Coding standards page.

References:
- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
- [Using the PHP Code Beautifier and Fixer](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically#using-the-php-code-beautifier-and-fixer)