### PR TITLE
Handle `pending` status using WebHook and manual update

### DIFF
--- a/src/admin/controller/payment/omise_offsite.php
+++ b/src/admin/controller/payment/omise_offsite.php
@@ -135,6 +135,36 @@ class ControllerPaymentOmiseOffsite extends Controller
         }
     }
 
+    public function action() {
+        if (empty($this->request->get['order_id'])) {
+            return;
+        }
+
+        $this->load->model('sale/order');
+        $this->load->model('payment/omise');
+
+        $order_info = $this->model_sale_order->getOrder($this->request->get['order_id']);
+
+        if (empty($order_info)) {
+            return;
+        }
+
+        $this->load->model('localisation/order_status');
+        $this->load->language('payment/omise_offsite_action');
+
+        $data = array(
+            'text_loading'   => $this->language->get('text_loading'),
+            'button_refresh' => $this->language->get('button_refresh'),
+
+            'order_id'        => $this->request->get['order_id'],
+            'order_status_id' => $order_info['order_status_id'],
+            'order_status'    => $this->model_localisation_order_status->getOrderStatus($order_info['order_status_id']),
+
+            'token' => $this->session->data['token'],
+        );
+        return $this->load->view('payment/omise_offsite_action.tpl', $data);
+    }
+
     /**
      * This method will fire when user click `install` button from `extension/payment` page
      * It will call `model/payment/omise_offsite.php` file and run `install` method for installl stuff

--- a/src/admin/language/english/payment/omise_offsite_action.php
+++ b/src/admin/language/english/payment/omise_offsite_action.php
@@ -1,0 +1,3 @@
+<?php
+$_['text_loading']     = 'Loading';
+$_['button_refresh']   = 'Refresh Order Status';

--- a/src/admin/view/template/payment/omise_offsite_action.tpl
+++ b/src/admin/view/template/payment/omise_offsite_action.tpl
@@ -1,0 +1,57 @@
+<div id="action"></div>
+<br />
+<dl>
+  <dt>Order Status:</dt>
+  <dd id="order-status-action"><?= $order_status['name'] ?></dd>
+</dl>
+<button id="button-refresh" data-loading-text="<?= $text_loading; ?>" class="btn btn-primary" style="display: none;"><i class="fa fa-refresh"></i> <?= $button_refresh; ?></button>
+<script type="text/javascript"><!--
+$(document).ready(function() {
+  if ($('select[name="order_status_id"]').val() == 2) {
+    $('#button-refresh').show();
+  }
+});
+$('#button-history').on('click', function() {
+  if ($('select[name="order_status_id"]').val() == 2) {
+    $('#order-status-action').html($('select[name=\'order_status_id\'] option:selected').text());
+    $('#button-refresh').show();
+  }
+});
+$('#button-refresh').on('click', function() {
+  $.ajax({
+    url: 'index.php?route=sale/order/api&api=payment/omise/refresh&token=<?= $token ?>&order_id=<?= $order_id ?>',
+    type: 'get',
+    dataType: 'json',
+    beforeSend: function() {
+      $('#button-refresh').button('loading');
+    },
+    complete: function() {
+      $('#button-refresh').button('reset');
+    },
+    success: function(json) {
+      $('.alert').remove();
+
+      if (json['error']) {
+        $('#action').before('<div class="alert alert-danger"><i class="fa fa-exclamation-circle"></i> ' + json['error'] + ' <button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+      }
+
+      if (json['success']) {
+        $('#action').before('<div class="alert alert-success"><i class="fa fa-check-circle"></i> ' + json['success'] + ' <button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+      }
+
+      if (json['new_status']) {
+        $('#order-status').text(json['new_status']);
+        $('#order-status-action').text(json['new_status']);
+        $('#button-refresh').hide();
+        $('select[name="order_status_id"]').val(json['new_status_id']); 
+
+        // cloned from sales/order/info
+        $('#history').load('index.php?route=sale/order/history&token=<?php echo $token; ?>&order_id=<?php echo $order_id; ?>');
+      }
+    },
+    error: function(xhr, ajaxOptions, thrownError) {
+      alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+    }
+  });
+});
+//--></script>

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -16,7 +16,7 @@ class ControllerPaymentOmise extends Controller {
 	}
 
 	public function checkoutCallback() {
-		if ($this->request->get['order_id']) {
+		if (isset($this->request->get['order_id'])) {
 			$this->load->library('omise');
 			$this->load->library('omise-php/lib/Omise');
 			$this->load->model('payment/omise');
@@ -27,18 +27,21 @@ class ControllerPaymentOmise extends Controller {
 			$transaction = $this->model_payment_omise->getChargeTransaction($this->request->get['order_id']);
 
 			$charge = OmiseCharge::retrieve($transaction->row['omise_charge_id'], $omise_keys['pkey'], $omise_keys['skey']);
+
 			if ($charge && $charge['authorized'] && $charge['captured']) {
 				// Status: processed.
 				$this->model_checkout_order->addOrderHistory($order_id, 15);
 				$this->response->redirect($this->url->link('checkout/success'));
+			} elseif ($charge && $charge['status'] == 'pending') {
+				$this->renderWaitingPage();
 			} else {
 				// Status: failed.
-				$this->model_checkout_order->addOrderHistory($order_id, 10);
+				$this->model_checkout_order->addOrderHistory($order_id, 10, $charge['failure_message']);
 				$this->response->redirect($this->url->link('checkout/failure'));
 			}
+		} else {
+			$this->response->redirect($this->url->link('common/home'));
 		}
-
-		exit;
 	}
 
 	/**
@@ -214,4 +217,147 @@ class ControllerPaymentOmise extends Controller {
 			}
 		}
 	}
+
+    public function processing()
+    {
+        if (! isset($this->request->get['order_id'])) {
+            return;
+        }
+
+        if (isset($this->session->data['order_id'])) {
+            $backup_order_id = $this->session->data['order_id'];
+        }
+
+        // Reuse success logic from OpenCart to cleanup current cart.
+        // And checkout/success only works with session->data['order_id'].
+        $this->session->data['order_id'] = $this->request->get['order_id'];
+        $this->load->controller('checkout/success');
+        if (isset($backup_order_id)) {
+            $this->session->data['order_id'] = $backup_order_id;
+        }
+
+        // But display our page.
+        $this->load->language('payment/omise_processing');
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $data['breadcrumbs'] = array();
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/home')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_basket'),
+            'href' => $this->url->link('checkout/cart')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_checkout'),
+            'href' => $this->url->link('checkout/checkout', '', 'SSL')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_processing'),
+            'href' => $this->url->link('payment/omise/processing')
+        );
+
+        $data['heading_title'] = $this->language->get('heading_title');
+
+        if ($this->customer->isLogged()) {
+            $data['text_message'] = sprintf(
+                $this->language->get('text_customer'),
+                $this->url->link('account/account', '', 'SSL'),
+                $this->url->link('account/order', '', '    SSL'),
+                $this->url->link('account/download', '', 'SSL'),
+                $this->url->link('information/contact')
+            );
+        } else {
+            $data['text_message'] = sprintf(
+                $this->language->get('text_guest'),
+                $this->url->link('information/contact')
+            );
+        }
+
+        $data['button_continue'] = $this->language->get('button_continue');
+
+        $data['continue'] = $this->url->link('common/home');
+
+        $data['column_left'] = $this->load->controller('common/column_left');
+        $data['column_right'] = $this->load->controller('common/column_right');
+        $data['content_top'] = $this->load->controller('common/content_top');
+        $data['content_bottom'] = $this->load->controller('common/content_bottom');
+        $data['footer'] = $this->load->controller('common/footer');
+        $data['header'] = $this->load->controller('common/header');
+
+        if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/common/success.tpl')) {
+            $this->response->setOutput(
+                $this->load->view($this->config->get('config_template') . '/template/common/success.tpl', $data)
+            );
+        } else {
+            $this->response->setOutput($this->load->view('default/template/common/success.tpl', $data));
+        }
+    }
+
+    private function renderWaitingPage()
+    {
+        $omise_waiting = 'omise_waiting_' . $this->request->get['order_id'];
+
+        if (! isset($this->session->data[$omise_waiting])) {
+            $this->session->data[$omise_waiting] = 1;
+        } else {
+            $this->session->data[$omise_waiting]++;
+            if ($this->session->data[$omise_waiting] > 5) {
+                $this->response->redirect(
+                    $this->url->link('payment/omise/processing', 'order_id=' . $this->request->get['order_id'])
+                );
+                return;
+            }
+        }
+
+        $this->load->language('checkout/success');
+        $this->load->language('payment/omise_waiting');
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $data['breadcrumbs'] = array();
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/home')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_basket'),
+            'href' => $this->url->link('checkout/cart')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_checkout'),
+            'href' => $this->url->link('checkout/checkout', '', 'SSL')
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_waiting'),
+            'href' => $this->url->link('payment/omise/checkoutcallback', 'order_id=' . $this->request->get['order_id'])
+        );
+
+        $data['heading_title'] = $this->language->get('heading_title');
+
+        $data['text_message'] = $this->language->get('text_message');
+
+        $data['column_left'] = $this->load->controller('common/column_left');
+        $data['column_right'] = $this->load->controller('common/column_right');
+        $data['content_top'] = $this->load->controller('common/content_top');
+        $data['content_bottom'] = $this->load->controller('common/content_bottom');
+        $data['footer'] = $this->load->controller('common/footer');
+        $data['header'] = $this->load->controller('common/header');
+
+        if (file_exists(DIR_TEMPLATE . $this->config->get('config_template') . '/template/payment/omise_waiting.tpl')) {
+            $this->response->setOutput(
+                $this->load->view($this->config->get('config_template') . '/template/payment/omise_waiting.tpl', $data)
+            );
+        } else {
+            $this->response->setOutput($this->load->view('default/template/payment/omise_waiting.tpl', $data));
+        }
+    }
 }

--- a/src/catalog/language/english/payment/omise_processing.php
+++ b/src/catalog/language/english/payment/omise_processing.php
@@ -1,0 +1,5 @@
+<?php
+$_['heading_title']   = 'Your order is being processed';
+$_['text_processing'] = 'Processing';
+$_['text_customer']   = '<p>Your order is being processed. We will response you back once the payment is complete.</p><p>You can view your order history by going to the <a href="%s">my account</a> page and by clicking on <a href="%s">history</a>.</p><p>If your purchase has an associated download, you can go to the account <a href="%s">downloads</a> page to view them.</p><p>Please direct any questions you have to the <a href="%s">store owner</a>.</p><p>Thanks for shopping with us online!</p>';
+$_['text_guest']      = '<p>Your order is being processed. We will response you back once the payment is complete.</p><p>Please direct any questions you have to the <a href="%s">store owner</a>.</p><p>Thanks for shopping with us online!</p>';

--- a/src/catalog/language/english/payment/omise_waiting.php
+++ b/src/catalog/language/english/payment/omise_waiting.php
@@ -1,0 +1,4 @@
+<?php
+$_['heading_title'] = 'Waiting for payment result';
+$_['text_waiting']  = 'Waiting';
+$_['text_message']  = 'Order completed, we are waiting for payment result. Please wait for a moment and do not close this page.';

--- a/src/catalog/model/payment/omise.php
+++ b/src/catalog/model/payment/omise.php
@@ -51,6 +51,10 @@ class ModelPaymentOmise extends Model {
         else
             return $this->db->query("SELECT * FROM `" . DB_PREFIX . "omise_charge`");
     }
+
+    public function getOrderId($charge_id) {
+        return $this->db->query("SELECT * FROM `" . DB_PREFIX . "omise_charge` WHERE omise_charge_id = '" . $charge_id. "'");
+    }
 }
 
 

--- a/src/catalog/view/theme/default/template/payment/omise_waiting.tpl
+++ b/src/catalog/view/theme/default/template/payment/omise_waiting.tpl
@@ -1,0 +1,25 @@
+<?php echo $header; ?>
+<div class="container">
+  <ul class="breadcrumb">
+    <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <li><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a></li>
+    <?php } ?>
+  </ul>
+  <div class="row"><?php echo $column_left; ?>
+    <?php if ($column_left && $column_right) { ?>
+    <?php $class = 'col-sm-6'; ?>
+    <?php } elseif ($column_left || $column_right) { ?>
+    <?php $class = 'col-sm-9'; ?>
+    <?php } else { ?>
+    <?php $class = 'col-sm-12'; ?>
+    <?php } ?>
+    <div id="content" class="<?php echo $class; ?>"><?php echo $content_top; ?>
+      <h1><?php echo $heading_title; ?></h1>
+      <?php echo $text_message; ?>
+      <?php echo $content_bottom; ?></div>
+    <?php echo $column_right; ?></div>
+</div>
+<?php echo $footer; ?>
+<script type="text/javascript">
+window.setTimeout('location.reload()', 5000);
+</script>


### PR DESCRIPTION
**This PR requires #41 to be merged first.**

#### 1. Objective

After offsite processor redirects customer back to OpenCart, there is a small chance that the charge status will still be `pending`. This PR handles that status by:

- Rendering a *waiting* page that keeps refreshing the charge status every 5 seconds for 5 times.
- After 5 refreshes, if charge status is still pending, it will redirect customer to processing page to instruct customer that the payment is being processed.
- Support [WebHook](https://www.omise.co/api-webhooks) for background updating.
- Add *Action* page that allows merchant to manually refresh charge status.

#### 2. Description of change

- *CATALOG* `payment/omise/checkoutcallback` now renders a HTML page (waiting page).
- *CATALOG* Add `payment/omise/webhook` to support WebHook.
- *ADMIN* Add `payment/omise/action` to support manual refresh.
![action](https://cloud.githubusercontent.com/assets/245383/25125998/eeaa3222-245a-11e7-8545-c3f03dd5d11b.png)

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: OpenCart 2.0.3.1.
- **Omise plugin version**: Omise-OpenCart 2.0.0.1
- **PHP versions**: 7.0.17

**✏️ Details:**

To test the `pending` state, tester must apply the following patch:

```diff
--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -28,6 +28,9 @@ class ControllerPaymentOmise extends Controller {

             $charge = OmiseCharge::retrieve($transaction->row['omise_charge_id'], $omise_keys['pkey'], $omise_keys['skey']);

+            $charge['captured'] = false;
+            $charge['status'] = 'pending';
+
             if ($charge && $charge['authorized'] && $charge['captured']) {
                 // Status: processed.
                 $this->model_checkout_order->addOrderHistory($order_id, 15);
```

Then try buying something, this will force rendering *waiting* page.
If the tester properly configures a WebHook, the order status will be automatically updated.

> Try [ngrok](https://ngrok.com) for redirecting WebHook to localhost.

If WebHook is not configured, visit *Admin* > *Orders* > *#someorder* > *Action*. The status should be *Processing*, then click *Refresh Order Status* and wait for a few moment, then the order status should be updated to *Processed*.

#### 4. Impact of the change

None, see new UI in chapter 3.

#### 5. Priority of change

Normal.

#### 6. Additional notes

None.