### PR TITLE
fix error `[] operator not supported for strings`

### DIFF
--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -79,8 +79,8 @@ class ControllerPaymentOmise extends Controller {
         $data = array();
         $data['omise_dashboard'] = array(
             'enabled' => $this->config->get('omise_status'),
-            'error'   => '',
-            'warning' => '',
+            'error'   => array(),
+            'warning' => array(),
         );
 
         if (! $data['omise_dashboard']['enabled']) {


### PR DESCRIPTION
change default value to empty array

#### 1. Objective

To fix issue that the Omise setting page shows an error or blank page after installed and clicked an edit button.

#### 2. Description of change

Change a default value from empty string to empty array.

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **Platform version**: OpenCart 2.0.3.1
- **Omise plugin version**: Omise-OpenCart 2.3.0
- **PHP version**: 7.1.22

**✏️ Details:**

1) Go to `Home`->`Payments` 
2) Click a button to install `Omise Payment`
3) Click an edit button

#### 4. Impact of the change

<img width="724" alt="02" src="https://user-images.githubusercontent.com/47804116/57502206-e3ce5080-7314-11e9-863a-c386c77dd77a.png">

<img width="752" alt="03" src="https://user-images.githubusercontent.com/47804116/57502268-2bed7300-7315-11e9-8614-49c756343672.png">


#### 5. Priority of change

Normal

#### 6. Additional notes

N/A