### PR TITLE
Add support for more currencies in OpenCart 2

### DIFF
--- a/src/system/library/omise-plugin/helpers/charge.php
+++ b/src/system/library/omise-plugin/helpers/charge.php
@@ -14,6 +14,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
         public static function amount($currency, $amount)
         {
             switch (strtoupper($currency)) {
+                case 'USD':
                 case 'THB':
                 case 'IDR':
                 case 'SGD':

--- a/src/system/library/omise-plugin/helpers/charge.php
+++ b/src/system/library/omise-plugin/helpers/charge.php
@@ -1,5 +1,5 @@
 <?php
-if (! class_exists('OmisePluginHelperCharge')) {
+if (!class_exists('OmisePluginHelperCharge')) {
     class OmisePluginHelperCharge
     {
         /**
@@ -14,6 +14,15 @@ if (! class_exists('OmisePluginHelperCharge')) {
         public static function amount($currency, $amount)
         {
             switch (strtoupper($currency)) {
+                case 'AUD':
+                case 'CAD':
+                case 'CHF':
+                case 'CNY':
+                case 'DKK':
+                case 'EUR':
+                case 'GBP':
+                case 'HKD':
+                case 'MYR':
                 case 'USD':
                 case 'THB':
                 case 'IDR':

--- a/src/system/library/omise-plugin/helpers/currency.php
+++ b/src/system/library/omise-plugin/helpers/currency.php
@@ -9,6 +9,7 @@ if (! class_exists('OmisePluginHelperCurrency')) {
         public static function isSupport($currency_code)
         {
             switch (strtoupper($currency_code)) {
+                case 'USD':
                 case 'THB':
                 case 'IDR':
                 case 'JPY':
@@ -52,6 +53,13 @@ if (! class_exists('OmisePluginHelperCurrency')) {
                         $amount = substr($amount, 0, -3);
                     }
                     break;
+                
+                case 'USD':
+                  $amount = "$" . number_format(($amount / 100), 2);
+                  if (preg_match('/\.00$/', $amount)) {
+                      $amount = substr($amount, 0, -3);
+                  }
+                  break;
             }
 
             return $amount;

--- a/src/system/library/omise-plugin/helpers/currency.php
+++ b/src/system/library/omise-plugin/helpers/currency.php
@@ -1,5 +1,5 @@
 <?php
-if (! class_exists('OmisePluginHelperCurrency')) {
+if (!class_exists('OmisePluginHelperCurrency')) {
     class OmisePluginHelperCurrency
     {
         /**
@@ -9,6 +9,15 @@ if (! class_exists('OmisePluginHelperCurrency')) {
         public static function isSupport($currency_code)
         {
             switch (strtoupper($currency_code)) {
+                case 'AUD':
+                case 'CAD':
+                case 'CHF':
+                case 'CNY':
+                case 'DKK':
+                case 'EUR':
+                case 'GBP':
+                case 'HKD':
+                case 'MYR':
                 case 'USD':
                 case 'THB':
                 case 'IDR':
@@ -29,18 +38,59 @@ if (! class_exists('OmisePluginHelperCurrency')) {
         public static function format($currency, $amount)
         {
             switch (strtoupper($currency)) {
+                case 'AUD':
+                    $amount = "A$" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'CAD':
+                    $amount = "C$" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'CHF':
+                    $amount = "CNF" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'CNY':
+                    $amount = "元" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'DKK':
+                    $amount = "DKK" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'EUR':
+                    $amount = "€" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'GBP':
+                    $amount = "£" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'HKD':
+                    $amount = "HK$" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
+                case 'MYR':
+                    $amount = "RM" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+
                 case 'THB':
                     $amount = "฿" . number_format(($amount / 100), 2);
-                    if (preg_match('/\.00$/', $amount)) {
-                        $amount = substr($amount, 0, -3);
-                    }
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
                     break;
 
                 case 'IDR':
                     $amount = "Rp" . number_format(($amount / 100), 2);
-                    if (preg_match('/\.00$/', $amount)) {
-                        $amount = substr($amount, 0, -3);
-                    }
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
                     break;
 
                 case 'JPY':
@@ -49,17 +99,22 @@ if (! class_exists('OmisePluginHelperCurrency')) {
 
                 case 'SGD':
                     $amount = "S$" . number_format(($amount / 100), 2);
-                    if (preg_match('/\.00$/', $amount)) {
-                        $amount = substr($amount, 0, -3);
-                    }
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
                     break;
-                
+
                 case 'USD':
-                  $amount = "$" . number_format(($amount / 100), 2);
-                  if (preg_match('/\.00$/', $amount)) {
-                      $amount = substr($amount, 0, -3);
-                  }
-                  break;
+                    $amount = "$" . number_format(($amount / 100), 2);
+                    $amount = OmisePluginHelperCurrency::_strip_zero_decimal($amount);
+                    break;
+            }
+
+            return $amount;
+        }
+
+        function _strip_zero_decimal($amount)
+        {
+            if (preg_match('/\.00$/', $amount)) {
+                $amount = substr($amount, 0, -3);
             }
 
             return $amount;


### PR DESCRIPTION
#### 1. Objective

Add support for more currencies in OpenCart 2 by following
- AUD
- CAD
- CHF
- CNY
- DKK
- EUR
- GBP
- HKD
- MYR
- USD

**Related information**:
- Related ticket(s): T20020 (Omise Internal Ticket)

#### 2. Description of change

Add more currencies support based on the current logic

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: OpenCart 2.0.3.1
- **Omise plugin version**: Omise-OpenCart 2.3
- **PHP version**: 7.0.15

**✏️ Details:**

N/A

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional notes

N/A