### PR TITLE
Auto detect 3DS and remove setting from backend.

### DIFF
--- a/src/admin/controller/payment/omise.php
+++ b/src/admin/controller/payment/omise.php
@@ -84,7 +84,7 @@ class ControllerPaymentOmise extends Controller {
         );
 
         if (! $data['omise_dashboard']['enabled']) {
-            $data['omise_dashboard']['error'][] = $this->language->get('error_extension_disabled');
+            $data['omise_dashboard']['error'] = $this->language->get('error_extension_disabled');
         } else {
             try {
                 // Retrieve Omise Account.
@@ -125,14 +125,14 @@ class ControllerPaymentOmise extends Controller {
 
                 // Check currency supports
                 if (! OmisePluginHelperCurrency::isSupport($this->config->get('config_currency'))) {
-                    $data['omise_dashboard']['warning'][] = sprintf(
+                    $data['omise_dashboard']['warning'] = sprintf(
                         $this->language->get('error_currency_not_support'),
                         $this->config->get('config_currency'),
                         $this->url->link('setting/store', 'token=' . $this->session->data['token'], 'SSL')
                     );
                 }
             } catch (Exception $e) {
-                $data['omise_dashboard']['error'][] = $this->searchErrorTranslation($e->getMessage());
+                $data['omise_dashboard']['error'] = $this->searchErrorTranslation($e->getMessage());
             }
         }
 
@@ -154,7 +154,6 @@ class ControllerPaymentOmise extends Controller {
         return array(
             'omise_status'        => $this->config->get('omise_status'),
             'omise_test_mode'     => $this->config->get('omise_test_mode'),
-            'omise_3ds'           => $this->config->get('omise_3ds'),
             'omise_pkey_test'     => $this->config->get('omise_pkey_test'),
             'omise_skey_test'     => $this->config->get('omise_skey_test'),
             'omise_pkey'          => $this->config->get('omise_pkey'),
@@ -208,7 +207,6 @@ class ControllerPaymentOmise extends Controller {
             'label_omise_skey'                        => $this->language->get('label_omise_skey'),
             'label_omise_mode_test'                   => $this->language->get('label_omise_mode_test'),
             'label_omise_mode_live'                   => $this->language->get('label_omise_mode_live'),
-            'label_omise_3ds'                         => $this->language->get('label_omise_3ds'),
             'label_omise_payment_title'               => $this->language->get('label_omise_payment_title'),
             'label_omise_payment_action'              => $this->language->get('label_omise_payment_action'),
             'text_mode_test'                          => $this->language->get('text_mode_test'),
@@ -335,8 +333,6 @@ class ControllerPaymentOmise extends Controller {
 
             $update = $this->request->post;
             if (! empty($update)) {
-                $update['omise_3ds'] = isset($update['omise_3ds']) ? $update['omise_3ds'] : 0;
-
                 // Update
                 $this->model_setting_setting->editSetting('omise', $update);
                 $this->session->data['success'] = $this->language->get('text_session_save');

--- a/src/admin/view/template/payment/omise.tpl
+++ b/src/admin/view/template/payment/omise.tpl
@@ -300,15 +300,6 @@ echo $header; ?><?php echo $column_left; ?>
               <h3 class="panel-title"><i class="fa fa-pencil"></i> <?php echo $label_setting_omise_config; ?></h3>
             </div>
             <div class="panel-body">
-              <!-- 3D-Secure -->
-              <div class="form-group">
-                <label class="col-sm-2 control-label" for="omise_payments_3ds"><?php echo $label_omise_3ds; ?></label>
-                <div class="col-sm-10">
-                  <div class="checkbox-inline">
-                    <input type="checkbox" name="omise_3ds" id="omise_payments_3ds" value="1" class="form-control" <?php echo $omise_3ds ? 'checked="checked"' : ''; ?> />
-                  </div>
-                </div>
-              </div> <!-- /END .3D-Secure -->
               <!-- Payment Action -->
               <div class="form-group">
                 <label class="col-sm-2 control-label" for="omise_auto_capture"><?php echo $label_omise_payment_action; ?></label>

--- a/src/catalog/controller/payment/omise.php
+++ b/src/catalog/controller/payment/omise.php
@@ -91,8 +91,8 @@ class ControllerPaymentOmise extends Controller {
 					}
 
 					$this->model_payment_omise->addChargeTransaction($order_id, $omise_charge['id']);
-
-					if ($this->config->get('omise_3ds')) {
+					$authorizeUri = $omise_charge['authorize_uri'];
+					if ($omise_charge['status'] === "pending" && !$omise_charge['authorized'] && !$omise_charge['paid'] && !empty($authorizeUri)) {
 						// Status: processing.
 						$this->model_checkout_order->addOrderHistory($order_id, 2);
 


### PR DESCRIPTION
#### 1. Objective

This PR is to remove "Enable 3ds" setting from backend by detecting 3ds has been enabled automatically. 
If 3DS is enabled in omise account then after card payment it redirects to OTP authentication page, otherwise other gets placed and redirected to order success page.

**Related information**:
- Related ticket(s):  https://omise.atlassian.net/browse/FES-273

#### 2. Description of change



#### 3. Quality assurance
**🔧 Environments:**
i.e.
- **Platform version**: OpenCart 2.3.0.1
- **Omise plugin version**: Omise-OpenCart 2.0.1.1
- **PHP version**: 5.6

**✏️ Details:**
- Update Omise private and secret key from 3DS enabled account.
- Checkout using card payment, after payment page it should redirect to OTP authentication page.
- Update Omise private and secret key from 3DS disabled account.
- Checkout using card payment, after payment page it should redirect to order confirmation page.

#### 4. Impact of the change

Setting for 3DS should be removed from backend

#### 5. Priority of change

Normal

#### 6. Additional notes
none